### PR TITLE
Fix op wrapper resilience in non-interactive shells

### DIFF
--- a/modules/secrets.zsh
+++ b/modules/secrets.zsh
@@ -1621,17 +1621,25 @@ if [[ -z "${OP_ALIAS_SHIM_DISABLE:-}" ]]; then
                     --account)
                         account="${args[$((i+1))]}"
                         out+=("--account")
-                        local resolved
-                        resolved="$(_op_resolve_account_arg "$account")"
-                        out+=("$resolved")
+                        if typeset -f _op_resolve_account_arg >/dev/null 2>&1; then
+                            local resolved
+                            resolved="$(_op_resolve_account_arg "$account")"
+                            out+=("$resolved")
+                        else
+                            out+=("$account")
+                        fi
                         i=$((i+2))
                         continue
                         ;;
                     --account=*)
                         account="${args[$i]#--account=}"
-                        local resolved2
-                        resolved2="$(_op_resolve_account_arg "$account")"
-                        out+=("--account=${resolved2}")
+                        if typeset -f _op_resolve_account_arg >/dev/null 2>&1; then
+                            local resolved2
+                            resolved2="$(_op_resolve_account_arg "$account")"
+                            out+=("--account=${resolved2}")
+                        else
+                            out+=("--account=${account}")
+                        fi
                         i=$((i+1))
                         continue
                         ;;


### PR DESCRIPTION
## Summary
- Guard `op()` alias shim against missing `_op_resolve_account_arg` helper function
- When the helper isn't available (e.g., Claude Code shell snapshots), pass the `--account` argument through unchanged instead of erroring
- Preserves full alias resolution when the complete secrets module is loaded

## Problem
In Claude Code and other environments that snapshot shell functions, the `op()` wrapper gets captured but `_op_resolve_account_arg` does not. This causes `command not found` errors that corrupt stdout and break JSON parsing from `op` commands.

## Also includes (prior commits on this branch)
- `op_signin_all`: persist session tokens to file for subprocesses
- OS and host-specific vars overrides
- Zsh startup scheduler and timeout probe fixes
- GitLab/data.world migration helpers

## Test plan
- [x] `op` commands work normally when full secrets module is loaded
- [x] `op --account X item get ...` degrades gracefully when helpers are missing