### PR TITLE
refactor: simplify backup remote to CI-only

### DIFF
--- a/modules/backup.zsh
+++ b/modules/backup.zsh
@@ -61,11 +61,8 @@ backup() {
         git push --set-upstream origin "$branch" && echo "✅ Pushed to main repo ($branch)"
     fi
     
-    # Push to backup repo if configured
-    if git remote | grep -q backup; then
-        git push backup "$branch" && echo "✅ Pushed to backup repo ($branch)"
-    fi
-    
+    # Backup mirror handled by CI (see .github/workflows/mirror.yml)
+
     echo "🎉 Backup complete"
 }
 
@@ -96,9 +93,6 @@ backup_merge_main() {
     if [[ "$source_branch" == "main" ]]; then
         git pull --ff-only origin main || return 1
         git push origin main || return 1
-        if git remote | grep -q backup; then
-            git push backup main || return 1
-        fi
         echo "✅ main pushed"
         return 0
     fi
@@ -116,9 +110,6 @@ backup_merge_main() {
     }
     merged=1
     git push origin main || return 1
-    if git remote | grep -q backup; then
-        git push backup main || return 1
-    fi
     [[ "$start_branch" != "main" ]] && git checkout "$start_branch" >/dev/null 2>&1 || true
     [[ "$merged" -eq 1 ]] && echo "✅ Merged and pushed: $source_branch -> main"
 }
@@ -138,11 +129,9 @@ repo_sync() {
     
     git pull origin main --rebase
     git push origin main
-    
-    if git remote | grep -q backup; then
-        git push backup main
-    fi
-    
+
+    # Backup mirror handled by CI (see .github/workflows/mirror.yml)
+
     echo "✅ Sync complete"
 }
 

--- a/tests/test-backup.zsh
+++ b/tests/test-backup.zsh
@@ -51,9 +51,7 @@ test_backup_pushes_current_branch() {
     ZSHRC_CONFIG_DIR="$work"
     out="$(backup "feature backup test" 2>&1 || true)"
     assert_contains "$out" "Pushed to main repo (feature/backup)" "should push active feature branch to origin"
-    assert_contains "$out" "Pushed to backup repo (feature/backup)" "should push active feature branch to backup remote"
     assert_command_success "git --git-dir '$root/origin.git' show-ref --verify --quiet refs/heads/feature/backup" "origin should have feature branch"
-    assert_command_success "git --git-dir '$root/backup.git' show-ref --verify --quiet refs/heads/feature/backup" "backup remote should have feature branch"
 
     ZSHRC_CONFIG_DIR="$old_dir"
     rm -rf "$root"
@@ -77,7 +75,6 @@ test_backup_merge_main_merges_and_returns_branch() {
     current="$(git -C "$work" branch --show-current)"
     assert_equal "feature/merge" "$current" "should return to original branch after merge"
     assert_command_success "git --git-dir '$root/origin.git' log --oneline main | grep -q \"feat: merge target\"" "origin main should include merged commit"
-    assert_command_success "git --git-dir '$root/backup.git' log --oneline main | grep -q \"feat: merge target\"" "backup main should include merged commit"
 
     ZSHRC_CONFIG_DIR="$old_dir"
     rm -rf "$root"


### PR DESCRIPTION
## Summary
- Remove manual backup remote pushes from `backup()`, `backup_merge_main()`, and `repo_sync()`
- Backup mirroring is now fully handled by CI via `.github/workflows/mirror.yml`
- Update backup tests to remove backup remote assertions

## Test plan
- [x] All 186 tests pass locally
- [ ] CI test check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)