### PR TITLE
fix: apply code review fixes across modules

### DIFF
--- a/modules/agents.zsh
+++ b/modules/agents.zsh
@@ -743,7 +743,7 @@ _agents_merge_codex_settings() {
     local approval="$3"
     local sandbox="$4"
 
-    python - "$out" "$role" "$approval" "$sandbox" <<'PY'
+    python3 - "$out" "$role" "$approval" "$sandbox" <<'PY'
 import json
 import os
 import sys

--- a/modules/backup.zsh
+++ b/modules/backup.zsh
@@ -37,7 +37,7 @@ backup() {
     echo "📦 Creating backup..."
     
     # Add all changes
-    git add -A
+    git add -u
     
     # Commit
     git commit -m "[$timestamp] $message" || {

--- a/modules/bitbucket.zsh
+++ b/modules/bitbucket.zsh
@@ -174,7 +174,7 @@ bb_repo_create() {
     fi
 
     local payload
-    payload="$(printf '{"scm":"git","is_private":%s,"name":"%s"}' "$private" "$name")"
+    payload="$(python3 -c "import json,sys; print(json.dumps({'scm':'git','is_private':sys.argv[1]=='true','name':sys.argv[2]}))" "$private" "$name")"
     if ! curl -fsS "${auth_args[@]}" \
         -H "Content-Type: application/json" \
         -X POST \

--- a/modules/credentials.zsh
+++ b/modules/credentials.zsh
@@ -50,22 +50,22 @@ _cred_put_op() {
     local service="$1" user="$2" value="$3"
     command -v op >/dev/null 2>&1 || return 1
     if op item get "$service-$user" >/dev/null 2>&1; then
-        op item edit "$service-$user" \
+        printf '%s' "$value" | op item edit "$service-$user" \
             ${OP_ACCOUNT:+--account="$OP_ACCOUNT"} \
             ${OP_VAULT:+--vault="$OP_VAULT"} \
-            "password=$value" >/dev/null 2>&1 && {
+            "password[password]=-" >/dev/null 2>&1 && {
             echo "✅ Updated in 1Password"
             return 0
         }
         return 1
     fi
-    op item create \
+    printf '%s' "$value" | op item create \
         --category="Login" \
         --title="$service-$user" \
         --vault="$OP_VAULT" \
         ${OP_ACCOUNT:+--account="$OP_ACCOUNT"} \
         "username=$user" \
-        "password=$value" \
+        "password[password]=-" \
         --tags="zsh-credentials" >/dev/null 2>&1 && {
         echo "✅ Stored in 1Password"
         return 0
@@ -92,6 +92,9 @@ _cred_get_keychain() {
 }
 
 _cred_put_keychain() {
+    # Note: macOS `security add-generic-password -w` does not support stdin;
+    # the password must be passed as a CLI argument. This is acceptable because
+    # Keychain operations require system authentication (Touch ID / password).
     local service="$1" user="$2" value="$3"
     command -v security >/dev/null 2>&1 || return 1
     security delete-generic-password -s "$service-$user" -a "$user" 2>/dev/null
@@ -286,13 +289,13 @@ ga_store_service_account() {
     echo "📧 Service Account: $client_email"
     echo "🎯 Project: $project_id"
     
-    op item create \
+    jq -r '.private_key' "$json_file" | op item create \
         --category="API Credential" \
         --title="GA-$project_id" \
         --vault="Private" \
         "project_id=$project_id" \
         "client_email=$client_email" \
-        "private_key[password]=$(jq -r '.private_key' "$json_file")" \
+        "private_key[password]=-" \
         "raw_json[text]=$(cat "$json_file")" \
         --tags="google-analytics,service-account"
     

--- a/modules/database.zsh
+++ b/modules/database.zsh
@@ -29,7 +29,8 @@ setup_postgres_credentials() {
     
     # Try to get from credential system
     if command -v get_credential >/dev/null 2>&1; then
-        local password=$(get_credential "postgres" "$PGUSER" "PASSWORD" 2>/dev/null)
+        local password
+        password=$(get_credential "postgres" "$PGUSER" "PASSWORD" 2>/dev/null)
         if [[ -n "$password" ]]; then
             export PGPASSWORD="$password"
             echo "✅ Loaded from secure storage"
@@ -39,12 +40,13 @@ setup_postgres_credentials() {
     
     # Interactive setup
     echo "Enter PostgreSQL password for $PGUSER@$PGHOST:"
+    local password store_it
     read -s password
     echo ""
-    
+
     if [[ -n "$password" ]]; then
         export PGPASSWORD="$password"
-        
+
         # Offer to store
         echo -n "Store password securely? (y/n): "
         read store_it

--- a/modules/databricks.zsh
+++ b/modules/databricks.zsh
@@ -316,7 +316,7 @@ dbx_lakebase_db_create() {
     _dbx_require_auth || return 1
     local instance_id
     instance_id="$(_dbx_lakebase_resolve_instance_id "$instance")"
-    _dbx_exec api post "/api/2.0/lakebase/instances/${instance_id}/databases" --json "{\"name\":\"${db}\"}"
+    _dbx_exec api post "/api/2.0/lakebase/instances/${instance_id}/databases" --json "$(python3 -c "import json,sys; print(json.dumps({'name':sys.argv[1]},separators=(',',':')))" "$db")"
 }
 
 dbx_lakebase_db_drop() {

--- a/modules/docker.zsh
+++ b/modules/docker.zsh
@@ -29,7 +29,8 @@ docker_status() {
     echo ""
     
     # Running containers
-    local running=$(docker ps -q | wc -l | tr -d ' ')
+    local running
+    running=$(docker ps -q | wc -l | tr -d ' ')
     echo "Running containers: $running"
     
     if [[ $running -gt 0 ]]; then
@@ -48,7 +49,8 @@ docker_cleanup() {
     echo ""
     
     # Remove stopped containers. `docker rm` returns 404 on some Desktop contexts.
-    local stopped_count=$(docker ps -aq --filter "status=exited" | wc -l | tr -d '[:space:]')
+    local stopped_count
+    stopped_count=$(docker ps -aq --filter "status=exited" | wc -l | tr -d '[:space:]')
     if [[ "$stopped_count" -gt 0 ]]; then
         echo "🗑️  Removing stopped containers..."
         docker container prune -f
@@ -57,7 +59,8 @@ docker_cleanup() {
     fi
     
     # Remove dangling images
-    local dangling=$(docker images -qf "dangling=true")
+    local dangling
+    dangling=$(docker images -qf "dangling=true")
     if [[ -n "$dangling" ]]; then
         echo "🗑️  Removing dangling images..."
         docker rmi $dangling
@@ -80,6 +83,7 @@ docker_deep_clean() {
     echo "===================="
     echo "⚠️  This will remove ALL unused resources"
     echo -n "Continue? (y/n): "
+    local confirm
     read confirm
     
     if [[ "$confirm" != "y" ]]; then
@@ -140,16 +144,27 @@ docker_quick_run() {
     docker run -it --rm "$image" /bin/bash
 }
 
+dstop() {
+    local ids
+    ids="$(docker ps -q)"
+    if [[ -z "$ids" ]]; then
+        echo "No running containers"
+        return 0
+    fi
+    docker stop $ids
+}
+
 # Aliases
 alias d='docker'
 alias dc='docker-compose'
 alias dps='docker ps'
 alias dpsa='docker ps -a'
 alias dimg='docker images'
-alias dstop='docker stop $(docker ps -q)'
 alias dexec='docker exec -it'
 alias dlogs='docker logs -f'
 
-echo "✅ docker loaded"
+if [[ -z "${ZSH_TEST_MODE:-}" ]]; then
+    echo "✅ docker loaded"
+fi
 
 

--- a/modules/utils.zsh
+++ b/modules/utils.zsh
@@ -9,9 +9,7 @@
 
 # Check if internet connection is available
 # Used by Spark to decide: local JARs vs Maven downloads
-is_online() {
-    ping -c 1 google.com &> /dev/null
-}
+is_online() { ping -c 1 -W 2 google.com &>/dev/null; }
 
 is_online_status() {
     is_online && echo "online" || echo "offline"
@@ -121,18 +119,19 @@ path_add() {
     fi
 }
 
-# Simple PATH deduplication
+# PATH deduplication using associative array (O(n))
 path_clean() {
-    local seen=()
+    typeset -A seen
     local cleaned=""
+    local dir
     for dir in ${(s/:/)PATH}; do
-        if [[ -d "$dir" ]] && [[ ! " ${seen[@]} " =~ " $dir " ]]; then
-            seen+=("$dir")
+        if [[ -d "$dir" ]] && (( ! ${+seen[$dir]} )); then
+            seen[$dir]=1
             cleaned="${cleaned:+$cleaned:}$dir"
         fi
     done
     export PATH="$cleaned"
-    echo "✅ PATH cleaned: $(echo $PATH | tr ':' '\n' | wc -l | tr -d ' ') directories"
+    echo "PATH cleaned: $(echo $PATH | tr ':' '\n' | wc -l | tr -d ' ') directories"
 }
 
 # Edit zsh configuration

--- a/tests/test-backup.zsh
+++ b/tests/test-backup.zsh
@@ -46,7 +46,7 @@ test_backup_pushes_current_branch() {
     root="$(_make_backup_test_repo)"
     work="$root/work"
     git -C "$work" checkout -b feature/backup >/dev/null 2>&1
-    echo "backup branch payload" > "$work/feature.txt"
+    echo "backup branch payload" >> "$work/README.md"
 
     ZSHRC_CONFIG_DIR="$work"
     out="$(backup "feature backup test" 2>&1 || true)"
@@ -86,7 +86,7 @@ test_pushmain_commits_pushes_and_merges() {
     root="$(_make_backup_test_repo)"
     work="$root/work"
     git -C "$work" checkout -b feature/pushmain >/dev/null 2>&1
-    echo "pushmain payload" > "$work/pushmain.txt"
+    echo "pushmain payload" >> "$work/README.md"
 
     ZSHRC_CONFIG_DIR="$work"
     out="$(pushmain "pushmain integration test" 2>&1 || true)"

--- a/tests/test-wiki.zsh
+++ b/tests/test-wiki.zsh
@@ -100,7 +100,7 @@ test_home_quick_commands_are_defined() {
         source "$ROOT_DIR/zshrc" >/dev/null 2>&1
         missing=0
         for fn in \
-            help zshconfig zshreboot backup secrets_profiles secrets_bootstrap_from_1p screen_ensure_pyenv \
+            zsh_help zshconfig zshreboot backup secrets_profiles secrets_bootstrap_from_1p screen_ensure_pyenv \
             toggle_hidden_files toggle_key_repeat \
             pyspark_shell spark_shell smart_spark_submit \
             setup_pyenv setup_uv python_status \

--- a/zshrc
+++ b/zshrc
@@ -249,7 +249,7 @@ fi
 rehash
 
 # Help
-help() {
+zsh_help() {
     echo "🚀 ZSH Quick Reference"
     echo "===================="
     echo ""
@@ -487,6 +487,7 @@ help() {
     echo ""
     echo "📚 Full docs: $ZSH_CONFIG_DIR/README.md"
 }
+alias zhelp='zsh_help'
 
 # Show loaded modules
 modules() {
@@ -818,7 +819,7 @@ zsh_status_banner() {
     # Quick tips
     echo ""
     printf "\033[%sm%s\033[%sm\n" "$accent_color" "💡 Quick Commands:" "$reset_color"
-    echo "   help          - Show all available commands"
+    echo "   zsh_help      - Show all available commands"
     echo "   modules       - List loaded modules"
     echo "   python_status - Check Python environment"
     echo "   spark_status  - Check Spark status"
@@ -846,8 +847,5 @@ fi
 # API Tokens
 # Keep tokens in secrets backends (secrets.env / 1Password map), not in git-tracked files.
 
-# pyenv (screen)
-if command -v pyenv >/dev/null 2>&1; then
-  eval "$(pyenv init --path)"
-  eval "$(pyenv init -)"
-fi
+# pyenv: canonical init is in modules/python.zsh (setup_pyenv)
+# For screen/tmux sessions, call setup_pyenv manually if needed


### PR DESCRIPTION
## Summary
- Rename `help()` to `zsh_help()` with `zhelp` alias (avoids shadowing built-in)
- `backup()`: `git add -A` → `git add -u` (prevents accidental staging of untracked secrets)
- Remove duplicate pyenv init from zshrc (canonical version in modules/python.zsh)
- `agents.zsh`: `python` → `python3`
- `credentials.zsh`: pipe passwords via stdin to 1Password CLI
- `bitbucket.zsh`, `databricks.zsh`: fix JSON injection using `python3 json.dumps()`
- `docker.zsh`: convert `dstop` alias to guarded function, add `local` declarations
- `database.zsh`: add `local` to password/store_it variables
- `utils.zsh`: optimize `path_clean()` O(n²)→O(n), add 2s timeout to `is_online()`

## Test plan
- [x] All 186 tests pass locally
- [ ] CI test check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)