### PR TITLE
Fix pyenv startup rehash and add Claude temp cleanup

### DIFF
--- a/modules/hadoop.zsh
+++ b/modules/hadoop.zsh
@@ -512,5 +512,5 @@ echo "✅ hadoop loaded"
 
 
 
-# Rehash to ensure commands are found
-rehash 2>/dev/null
+# Rehash to ensure commands are found without triggering pyenv rehash.
+builtin rehash 2>/dev/null

--- a/modules/python.zsh
+++ b/modules/python.zsh
@@ -23,9 +23,10 @@ if [[ -z "${ZSH_TEST_MODE:-}" ]] && command -v pyenv >/dev/null 2>&1; then
     export PYENV_ROOT="$HOME/.pyenv"
     export PATH="$PYENV_ROOT/bin:$PATH"
     
-    # Initialize pyenv (suppress rehash warnings - cosmetic sandbox issue)
-    eval "$(pyenv init --path 2>/dev/null)"
-    eval "$(pyenv init - 2>/dev/null)"
+    # Avoid pyenv startup rehash: on this shell config noclobber can make
+    # pyenv-rehash block for 60s trying to rewrite .pyenv-shim.
+    eval "$(pyenv init --path --no-rehash 2>/dev/null)"
+    eval "$(pyenv init - --no-rehash 2>/dev/null)"
     
     # Initialize virtualenv plugin if available
     if pyenv commands --bare 2>/dev/null | grep -q "^virtualenv-init$"; then

--- a/modules/screen.zsh
+++ b/modules/screen.zsh
@@ -27,16 +27,16 @@ PYENV
 
 # pyenv (screen)
 if command -v pyenv >/dev/null 2>&1; then
-  eval "$(pyenv init --path)"
-  eval "$(pyenv init -)"
+  eval "$(pyenv init --path --no-rehash)"
+  eval "$(pyenv init - --no-rehash)"
 fi
 PYENV
     elif [[ ! -f "$zshrc" ]]; then
         cat >> "$zshrc" <<'PYENV'
 # pyenv (screen)
 if command -v pyenv >/dev/null 2>&1; then
-  eval "$(pyenv init --path)"
-  eval "$(pyenv init -)"
+  eval "$(pyenv init --path --no-rehash)"
+  eval "$(pyenv init - --no-rehash)"
 fi
 PYENV
     fi

--- a/modules/utils.zsh
+++ b/modules/utils.zsh
@@ -184,6 +184,46 @@ zshreboot() {
     exec zsh
 }
 
+claude_tmp_cleanup() {
+    emulate -L zsh
+    set -euo pipefail
+
+    local base="${CLAUDE_TMP_DIR:-/System/Volumes/Data/private/tmp/claude-501}"
+    local min_gb="${1:-1}"
+    local dry_run="${2:-false}"
+    local found=()
+
+    if [[ ! -d "$base" ]]; then
+        echo "⚠️  Claude temp directory not found: $base"
+        return 0
+    fi
+
+    while IFS= read -r path; do
+        [[ -n "$path" ]] && found+=("$path")
+    done < <(/usr/bin/find "$base" -type f -name "*.output" -size +"${min_gb}"G -print 2>/dev/null)
+
+    if (( ${#found[@]} == 0 )); then
+        echo "✅ No Claude temp output files >= ${min_gb}G in $base"
+        return 0
+    fi
+
+    echo "🧹 Claude temp outputs >= ${min_gb}G"
+    /bin/ls -lh "${found[@]}" 2>/dev/null || true
+
+    if [[ "$dry_run" == "true" ]]; then
+        echo "🧪 Dry run only. Nothing deleted."
+        return 0
+    fi
+
+    # Stop known writers before deleting their runaway temp outputs.
+    /usr/bin/pkill -f claude >/dev/null 2>&1 || true
+    /usr/bin/pkill -f craft-agent >/dev/null 2>&1 || true
+
+    /bin/rm -f "${found[@]}"
+    echo "✅ Deleted ${#found[@]} Claude temp output file(s)"
+    /bin/df -h /System/Volumes/Data 2>/dev/null || true
+}
+
 setup_pyenv() {
     if ! command -v pyenv >/dev/null 2>&1; then
         echo "❌ pyenv not found on PATH" >&2
@@ -192,8 +232,8 @@ setup_pyenv() {
     fi
     export PYENV_ROOT="${PYENV_ROOT:-$HOME/.pyenv}"
     [[ ":$PATH:" == *":$PYENV_ROOT/bin:"* ]] || export PATH="$PYENV_ROOT/bin:$PATH"
-    eval "$(pyenv init --path 2>/dev/null)"
-    eval "$(pyenv init - 2>/dev/null)"
+    eval "$(pyenv init --path --no-rehash 2>/dev/null)"
+    eval "$(pyenv init - --no-rehash 2>/dev/null)"
     echo "✅ pyenv initialized"
     pyenv --version 2>/dev/null | head -n 1 || true
 }
@@ -272,4 +312,3 @@ alias zshreload='zshreboot'
 alias editconfig='zshconfig'
 
 echo "✅ utils loaded"
-

--- a/modules/zeppelin.zsh
+++ b/modules/zeppelin.zsh
@@ -254,7 +254,7 @@ zeppelin_start() {
         if [[ -n "$spark_home" && -d "$spark_home/bin" ]]; then
             export PATH="$spark_home/bin:$PATH"
             export SPARK_HOME="$spark_home"
-            rehash 2>/dev/null || true
+            builtin rehash 2>/dev/null || true
             unset SPARK_VERSION
             unset SPARK_SCALA_VERSION
             unset SPARK_KAFKA_VERSION

--- a/tests/test-python.zsh
+++ b/tests/test-python.zsh
@@ -117,3 +117,11 @@ register_test "test_python_status_with_pyenv" "test_python_status_with_pyenv"
 register_test "test_python_status_uses_python3_shim" "test_python_status_uses_python3_shim"
 register_test "test_python_config_status_defined" "test_python_config_status_defined"
 register_test "test_pyenv_default_venv_variable" "test_pyenv_default_venv_variable"
+
+test_python_module_uses_no_rehash() {
+    local file="$ROOT_DIR/modules/python.zsh"
+    assert_true "grep -Fq 'pyenv init --path --no-rehash' \"$file\"" "python module should disable pyenv startup rehash for --path"
+    assert_true "grep -Fq 'pyenv init - --no-rehash' \"$file\"" "python module should disable pyenv startup rehash for shell init"
+}
+
+register_test "test_python_module_uses_no_rehash" "test_python_module_uses_no_rehash"

--- a/tests/test-utils.zsh
+++ b/tests/test-utils.zsh
@@ -57,6 +57,7 @@ CURL
 
 test_legacy_quick_commands_defined() {
     assert_true "typeset -f setup_pyenv >/dev/null 2>&1" "setup_pyenv should be defined"
+    assert_true "typeset -f claude_tmp_cleanup >/dev/null 2>&1" "claude_tmp_cleanup should be defined"
     assert_true "typeset -f setup_uv >/dev/null 2>&1" "setup_uv should be defined"
     assert_true "typeset -f toggle_hidden_files >/dev/null 2>&1" "toggle_hidden_files should be defined"
     assert_true "typeset -f toggle_key_repeat >/dev/null 2>&1" "toggle_key_repeat should be defined"
@@ -70,7 +71,32 @@ test_legacy_quick_commands_defined() {
     assert_true "typeset -f test_bash_install >/dev/null 2>&1" "test_bash_install should be defined"
 }
 
+test_claude_tmp_cleanup_dry_run_and_delete() {
+    local tmp old_dir out
+    tmp="$(mktemp -d)"
+    mkdir -p "$tmp/tasks"
+    old_dir="${CLAUDE_TMP_DIR-}"
+    export CLAUDE_TMP_DIR="$tmp"
+    truncate -s 2G "$tmp/tasks/runaway.output"
+
+    out="$(claude_tmp_cleanup 1 true)"
+    assert_contains "$out" "Dry run only" "dry run should not delete files"
+    assert_true "[[ -f \"$tmp/tasks/runaway.output\" ]]" "dry run should keep file"
+
+    out="$(claude_tmp_cleanup 1 false)"
+    assert_contains "$out" "Deleted 1 Claude temp output file" "delete run should report deletion"
+    assert_true "[[ ! -e \"$tmp/tasks/runaway.output\" ]]" "delete run should remove file"
+
+    if [[ -n "$old_dir" ]]; then
+        export CLAUDE_TMP_DIR="$old_dir"
+    else
+        unset CLAUDE_TMP_DIR
+    fi
+    rm -rf "$tmp"
+}
+
 register_test "utils_command_exists" test_command_exists_basic
 register_test "utils_path_add_clean" test_path_add_and_clean
 register_test "utils_download_jars" test_download_jars_stub
 register_test "utils_legacy_quick_commands_defined" test_legacy_quick_commands_defined
+register_test "utils_claude_tmp_cleanup" test_claude_tmp_cleanup_dry_run_and_delete

--- a/wiki/Module-Python.md
+++ b/wiki/Module-Python.md
@@ -27,3 +27,4 @@ Python/pyenv management and data‑science helpers.
 
 ## Notes
 - `python_status` falls back to system Python if pyenv unavailable.
+- Startup uses `pyenv init ... --no-rehash` to avoid 60-second stalls from pyenv shim lock contention.

--- a/wiki/Module-Utils.md
+++ b/wiki/Module-Utils.md
@@ -23,7 +23,9 @@ Core utility helpers and shared variables.
 | `path_clean` | Deduplicate `PATH` | `PATH` mutation | Directories are readable |
 | `zshconfig` | Open config dir in editor | `$EDITOR` | Editor installed |
 | `zshreboot` | Restart shell | `exec zsh` | Zsh installed |
+| `claude_tmp_cleanup` | Remove oversized Claude temp outputs | `find`, `pkill`, `rm`, `df` | Claude temp dir readable |
 
 ## Notes
 - `download_jars` writes into `JARS_DIR` by default.
 - `extract` is extension-based (no content detection).
+- `claude_tmp_cleanup [min_gb] [dry_run]` defaults to `/System/Volumes/Data/private/tmp/claude-501` and can be overridden with `CLAUDE_TMP_DIR`.

--- a/zshrc
+++ b/zshrc
@@ -245,8 +245,8 @@ if [[ -n "$SPARK_HOME" && -d "$SPARK_HOME/bin" ]]; then
     [[ ":$PATH:" != *":$SPARK_HOME/sbin:"* ]] && export PATH="$SPARK_HOME/sbin:$PATH"
 fi
 
-# Rehash command table after PATH changes
-rehash
+# Rehash command table after PATH changes without invoking pyenv's wrapper.
+builtin rehash
 
 # Help
 zsh_help() {
@@ -261,6 +261,7 @@ zsh_help() {
     echo "  pyenv_use_version <v>  - pyenv shell <version>"
     echo "  pyenv_default_version <v> - pyenv global <version>"
     echo "  ds_project_init <name> - Create data science project"
+    echo "  claude_tmp_cleanup [min_gb] [dry_run] - Remove runaway Claude temp outputs"
     echo ""
     echo "⚡ Spark:"
     echo "  spark_start            - Start Spark cluster"


### PR DESCRIPTION
## Summary
- disable pyenv startup rehash to avoid 60-second shell stalls
- use builtin rehash where the shell only needs command table refresh
- add claude_tmp_cleanup helper for runaway Claude temp outputs
- add focused tests and module docs

## Verification
- direct functional check: claude_tmp_cleanup dry-run and delete path both passed
- interactive startup check: zsh -i completed without pyenv rehash delay
