### PR TITLE
Prefer agent cache for startup secrets

### DIFF
--- a/modules/secrets.zsh
+++ b/modules/secrets.zsh
@@ -16,6 +16,7 @@
 : "${OP_SESSIONS_FILE:=$HOME/.config/zsh/.op-sessions.env}"
 : "${ZSH_OP_SOURCE_ACCOUNT:=Dheeraj_Chand_Family}"
 : "${ZSH_OP_SOURCE_VAULT:=Private}"
+: "${ZSH_SECRETS_STARTUP_SOURCE:=auto}" # auto|live|cache
 _SECRETS_SYNC_FILES=(op-accounts.env secrets.env secrets.1p codex-sessions.env)
 
 # Resolve JSON tool once: prefer jq, fall back to python3, then python
@@ -130,6 +131,22 @@ _secrets_normalize_mode() {
     if [[ -n "${ZSH_SECRETS_MODE:-}" ]]; then
         export ZSH_SECRETS_MODE="$(_secrets_normalize_value "$ZSH_SECRETS_MODE")"
     fi
+}
+
+_secrets_startup_prefers_agent_cache() {
+    local mode="${ZSH_SECRETS_STARTUP_SOURCE:-auto}"
+    mode="${mode:l}"
+    case "$mode" in
+        cache) return 0 ;;
+        live) return 1 ;;
+        auto)
+            [[ "${ZSH_IS_IDE_TERMINAL:-0}" == "1" ]] && [[ -f "${SECRETS_AGENT_ENV_FILE:-$HOME/.config/zsh/.agent-secrets.env}" ]]
+            return $?
+            ;;
+        *)
+            return 1
+            ;;
+    esac
 }
 
 _secrets_strip_crlf() {
@@ -1259,6 +1276,10 @@ load_secrets() {
         off) return 0 ;;
         file) secrets_load_file ;;
         op)
+            if _secrets_startup_prefers_agent_cache; then
+                _secrets_info "startup using agent cache"
+                secrets_agent_source && return 0
+            fi
             secrets_load_op || {
                 if [[ -f "$_agent_cache" ]]; then
                     _secrets_info "op auth unavailable, loading from agent cache"
@@ -1268,6 +1289,10 @@ load_secrets() {
             ;;
         both)
             secrets_load_file
+            if _secrets_startup_prefers_agent_cache; then
+                _secrets_info "startup using agent cache"
+                secrets_agent_source && return 0
+            fi
             secrets_load_op || {
                 if [[ -f "$_agent_cache" ]]; then
                     _secrets_info "op auth unavailable, loading from agent cache"

--- a/tests/test-secrets.zsh
+++ b/tests/test-secrets.zsh
@@ -1517,6 +1517,42 @@ test_load_secrets_falls_back_to_agent_cache() {
     rm -rf "$tmp"
 }
 
+test_load_secrets_prefers_agent_cache_in_ide_mode() {
+    local tmp old_cache old_mode old_startup_source old_ide old_secret
+    tmp="$(mktemp -d)"
+    old_cache="${SECRETS_AGENT_ENV_FILE-}"
+    old_mode="${ZSH_SECRETS_MODE-}"
+    old_startup_source="${ZSH_SECRETS_STARTUP_SOURCE-}"
+    old_ide="${ZSH_IS_IDE_TERMINAL-}"
+    old_secret="${MY_SECRET-}"
+
+    export SECRETS_AGENT_ENV_FILE="$tmp/.agent-secrets.env"
+    cat > "$SECRETS_AGENT_ENV_FILE" <<'EOF'
+MY_SECRET=cached_value
+EOF
+    export ZSH_SECRETS_MODE="op"
+    export ZSH_SECRETS_STARTUP_SOURCE="auto"
+    export ZSH_IS_IDE_TERMINAL="1"
+    unset MY_SECRET
+
+    secrets_load_op() {
+        echo "live-secrets-should-not-run" >&2
+        return 1
+    }
+
+    load_secrets >/dev/null 2>&1
+
+    assert_equal "cached_value" "${MY_SECRET:-}" "IDE startup should prefer agent cache over live op reads"
+
+    unfunction secrets_load_op 2>/dev/null || true
+    export SECRETS_AGENT_ENV_FILE="$old_cache"
+    export ZSH_SECRETS_MODE="$old_mode"
+    export ZSH_SECRETS_STARTUP_SOURCE="$old_startup_source"
+    export ZSH_IS_IDE_TERMINAL="$old_ide"
+    export MY_SECRET="$old_secret"
+    rm -rf "$tmp"
+}
+
 register_test "test_secrets_load_file" "test_secrets_load_file"
 register_test "test_secrets_load_op" "test_secrets_load_op"
 register_test "test_secrets_load_op_supports_op_url_mapping" "test_secrets_load_op_supports_op_url_mapping"
@@ -1580,3 +1616,4 @@ register_test "test_secrets_agent_refresh_writes_agent_env" "test_secrets_agent_
 register_test "test_secrets_debug_silent_without_flag" "test_secrets_debug_silent_without_flag"
 register_test "test_secrets_debug_outputs_with_flag" "test_secrets_debug_outputs_with_flag"
 register_test "test_load_secrets_falls_back_to_agent_cache" "test_load_secrets_falls_back_to_agent_cache"
+register_test "test_load_secrets_prefers_agent_cache_in_ide_mode" "test_load_secrets_prefers_agent_cache_in_ide_mode"

--- a/wiki/Startup-Performance.md
+++ b/wiki/Startup-Performance.md
@@ -6,6 +6,7 @@ Interactive startup now takes a lighter path inside Warp by default.
 
 - `ZSH_STATUS_BANNER_MODE=auto` suppresses the probe-heavy status banner in Warp.
 - `ZSH_AUTO_RECOVER_MODE=auto` skips automatic service recovery in Warp.
+- `ZSH_SECRETS_STARTUP_SOURCE=auto` prefers the local agent cache over live 1Password reads when startup is running in the IDE/staggered path.
 
 Outside Warp, both settings still behave normally unless overridden.
 
@@ -16,6 +17,7 @@ Use these when you explicitly want the heavier interactive checks:
 ```zsh
 export ZSH_STATUS_BANNER_MODE=full
 export ZSH_AUTO_RECOVER_MODE=on
+export ZSH_SECRETS_STARTUP_SOURCE=live
 ```
 
 Use these when you want the lightest possible startup everywhere:
@@ -23,4 +25,5 @@ Use these when you want the lightest possible startup everywhere:
 ```zsh
 export ZSH_STATUS_BANNER_MODE=off
 export ZSH_AUTO_RECOVER_MODE=off
+export ZSH_SECRETS_STARTUP_SOURCE=cache
 ```


### PR DESCRIPTION
## Summary
- prefer the local agent secrets cache during IDE/staggered startup
- avoid live 1Password reads on the startup hot path when cache is already available
- document the startup secrets behavior

## Why
After the Warp banner fix, startup was still slow because the secrets module was performing live 1Password reads before prompt readiness in the staggered startup path. Startup should use the local agent cache by default and reserve live 1Password reads for explicit actions or cache-miss recovery.

## Verification
- before patch: zsh -i -c "echo READY" took about 24s in this environment
- after patch: zsh -i -c "echo READY" completed in about 0.35s
- observed startup output now shows "startup using agent cache" instead of a live 1Password load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ZSH_SECRETS_STARTUP_SOURCE` configuration variable with auto, live, and cache modes to control startup behavior.
  * Startup now intelligently adapts initialization based on environment settings and file availability.

* **Documentation**
  * Updated startup performance documentation with new configuration option and usage examples for each mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->