### PR TITLE
fix: speed up Warp startup with compinit caching

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -16,7 +16,11 @@ export ZSH_CONFIG_DIR
 
 # Minimal init for non-TTY interactive shells (prevents GUI app timeouts)
 # Set ZSH_FORCE_FULL_INIT=1 to override.
-if [[ -o interactive && ! -t 0 && ! -t 1 && -z "${ZSH_FORCE_FULL_INIT:-}" ]]; then
+# Known terminal programs (Warp, VS Code, etc.) are always allowed full init.
+if [[ -o interactive && ! -t 0 && ! -t 1 && -z "${ZSH_FORCE_FULL_INIT:-}" \
+      && "$TERM_PROGRAM" != "WarpTerminal" \
+      && "$TERM_PROGRAM" != "vscode" \
+      && -z "${WARP_IS_LOCAL_SHELL_SESSION:-}" ]]; then
     if [[ "$OSTYPE" == "darwin"* ]]; then
         export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
     else
@@ -70,8 +74,14 @@ export ZSH="$HOME/.dotfiles/oh-my-zsh"
 ZSH_THEME="powerlevel10k/powerlevel10k"
 plugins=(git)
 
-# Initialize completion system
-autoload -Uz compinit && compinit
+
+# Initialize completion system (rebuild dump at most once per day)
+autoload -Uz compinit
+if [[ -f ~/.zcompdump && $(date +'%j') == $(stat -f '%Sm' -t '%j' ~/.zcompdump 2>/dev/null) ]]; then
+    compinit -C  # fast: skip security check, use cached dump
+else
+    compinit      # full rebuild
+fi
 
 # Warp is sensitive to noisy, probe-heavy interactive startup. Default it to a
 # lighter path unless explicitly overridden.


### PR DESCRIPTION
## Summary
- Cache `compinit` dump daily (`compinit -C`) instead of rebuilding every session — stale dump was 19 days old and causing unnecessary rebuilds
- Allow Warp and VS Code through the non-TTY early-exit guard so they get full interactive config instead of the minimal PATH-only fallback

## Context
Warp was showing "Seems like your shell is taking a while to start..." on every new tab. Root causes:
1. `compinit` rebuilding the completion dump every session (stale `~/.zcompdump`)
2. Warp/VS Code being caught by the non-TTY guard and getting only minimal PATH setup

Also separately fixed: missing `gitstatusd` binary (v1.5.4 installed, `build.info` updated to match) and cleared stale p10k caches.

## Test plan
- [x] `time TERM_PROGRAM=WarpTerminal /bin/zsh -i -c exit` → 485ms, no errors
- [x] No gitstatus error on startup
- [x] All 22 modules load successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced compatibility with WarpTerminal and VSCode terminals by fixing shell initialization to ensure proper configuration loading in these environments.

* **Performance**
  * Optimized shell startup performance through redesigned completion system initialization with intelligent caching strategy and daily cache refresh, reducing initialization overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->