### PR TITLE
Merge develop into main

### DIFF
--- a/modules/agents.zsh
+++ b/modules/agents.zsh
@@ -731,6 +731,197 @@ ai_init() {
     fi
 }
 
+# =================================================================
+# Electron app window repair
+# =================================================================
+# Electron apps sometimes launch with no visible window due to corrupt
+# or empty window state data. This generic function handles the fix for
+# any Electron app.
+#
+# Two window-state storage patterns exist in the wild:
+#   "standalone"  — a dedicated window-state.json (Craft Agents, Claude)
+#   "embedded"    — a key inside a larger JSON file like Preferences or
+#                   storage.json (VS Code, Cursor, Slack)
+#
+# Per-app wrappers below configure the right paths and call the generic
+# engine.  To add a new app, define a wrapper that calls
+# _electron_fix_window with the appropriate arguments.
+
+# --- generic engine ------------------------------------------------
+
+_electron_fix_window() {
+    local app_name=""           # display name, e.g. "Craft Agents"
+    local process_name=""       # killall target (defaults to app_name)
+    local app_path=""           # /Applications/Foo.app
+    local state_file=""         # path to window-state file
+    local state_format=""       # "standalone" | "embedded"
+    local state_key=""          # JSON key when format=embedded
+    local lock_files=()         # extra files to remove before relaunch
+    local state_builder=""      # optional function that prints the JSON value to write
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --app-name)      app_name="$2";      shift 2 ;;
+            --process-name)  process_name="$2";  shift 2 ;;
+            --app-path)      app_path="$2";      shift 2 ;;
+            --state-file)    state_file="$2";    shift 2 ;;
+            --state-format)  state_format="$2";  shift 2 ;;
+            --state-key)     state_key="$2";     shift 2 ;;
+            --lock-file)     lock_files+=("$2"); shift 2 ;;
+            --state-builder) state_builder="$2"; shift 2 ;;
+            *) echo "Unknown option: $1" >&2; return 1 ;;
+        esac
+    done
+
+    : "${process_name:=$app_name}"
+    local default_bounds='{ "x": 100, "y": 100, "width": 1200, "height": 800 }'
+
+    if [[ -z "$app_name" || -z "$state_file" || -z "$state_format" ]]; then
+        echo "Usage: _electron_fix_window --app-name NAME --state-file PATH --state-format standalone|embedded [options]" >&2
+        return 1
+    fi
+
+    echo "Repairing ${app_name}..."
+
+    # 1. Kill the app
+    killall "$process_name" 2>/dev/null
+    sleep "${ELECTRON_FIX_KILL_DELAY:-1}"
+
+    # 2. Remove stale lock files
+    local lf
+    for lf in "${lock_files[@]}"; do
+        [[ -f "$lf" ]] && rm -f "$lf" && echo "  Removed lock: $lf"
+    done
+
+    # 3. Build the replacement state value
+    local new_state
+    if [[ -n "$state_builder" ]]; then
+        new_state="$($state_builder)" || { echo "  State builder failed" >&2; return 1; }
+    else
+        new_state="$default_bounds"
+    fi
+
+    # 4. Write it
+    mkdir -p "${state_file:h}" 2>/dev/null
+    case "$state_format" in
+        standalone)
+            echo "$new_state" > "$state_file"
+            echo "  Wrote $state_file"
+            ;;
+        embedded)
+            if [[ -z "$state_key" ]]; then
+                echo "  --state-key required for embedded format" >&2; return 1
+            fi
+            if [[ ! -f "$state_file" ]]; then
+                echo "  State file not found: $state_file" >&2; return 1
+            fi
+            python3 -c "
+import json, sys
+path, key = sys.argv[1], sys.argv[2]
+new_val = json.loads(sys.argv[3])
+with open(path, 'r') as f:
+    data = json.load(f)
+data[key] = new_val
+with open(path, 'w') as f:
+    json.dump(data, f, indent=2)
+    f.write('\n')
+" "$state_file" "$state_key" "$new_state" || { echo "  Failed to patch $state_file" >&2; return 1; }
+            echo "  Patched key '$state_key' in $state_file"
+            ;;
+        *)
+            echo "  Unknown format: $state_format" >&2; return 1
+            ;;
+    esac
+
+    # 5. Relaunch
+    if [[ -n "$app_path" && -d "$app_path" ]]; then
+        open "$app_path"
+    else
+        open -a "$app_name"
+    fi
+    sleep "${ELECTRON_FIX_LAUNCH_DELAY:-3}"
+
+    # 6. Verify a window appeared
+    local wcount
+    wcount="$(osascript -e "
+        tell application \"System Events\"
+            tell process \"$process_name\"
+                return count of windows
+            end tell
+        end tell
+    " 2>/dev/null)"
+
+    if [[ "$wcount" -gt 0 ]]; then
+        echo "  Window visible ($wcount window(s))"
+    else
+        echo "  Warning: no window detected after repair." >&2
+        return 1
+    fi
+}
+
+# --- per-app wrappers ----------------------------------------------
+
+# Craft Agents: standalone window-state.json with workspace ID
+_craft_agents_state_builder() {
+    local config_file="$HOME/.craft-agent/config.json"
+    python3 -c "
+import json
+c = json.load(open('$config_file'))
+wid = c.get('activeWorkspaceId') or c.get('workspaces', [{}])[0].get('id', '')
+if not wid:
+    raise SystemExit('no workspace')
+print(json.dumps({
+    'windows': [{
+        'workspaceId': wid,
+        'bounds': {'x': 100, 'y': 100, 'width': 1200, 'height': 800},
+        'focused': True
+    }]
+}, indent=2))
+" 2>/dev/null
+}
+
+craft_agents_fix() {
+    _electron_fix_window \
+        --app-name      "Craft Agents" \
+        --app-path      "/Applications/Craft Agents.app" \
+        --state-file    "$HOME/.craft-agent/window-state.json" \
+        --state-format  standalone \
+        --lock-file     "$HOME/.craft-agent/.server.lock" \
+        --state-builder _craft_agents_state_builder
+}
+
+# Claude desktop: standalone window-state.json, flat bounds object
+claude_desktop_fix() {
+    _electron_fix_window \
+        --app-name      "Claude" \
+        --app-path      "/Applications/Claude.app" \
+        --state-file    "$HOME/Library/Application Support/Claude/window-state.json" \
+        --state-format  standalone
+}
+
+# VS Code: embedded in storage.json under "windowsState"
+vscode_fix() {
+    local storage="$HOME/Library/Application Support/Code/User/globalStorage/storage.json"
+    _electron_fix_window \
+        --app-name      "Code" \
+        --process-name  "Electron" \
+        --app-path      "/Applications/Visual Studio Code.app" \
+        --state-file    "$storage" \
+        --state-format  embedded \
+        --state-key     "windowsState"
+}
+
+# Cursor: same layout as VS Code
+cursor_fix() {
+    local storage="$HOME/Library/Application Support/Cursor/User/globalStorage/storage.json"
+    _electron_fix_window \
+        --app-name      "Cursor" \
+        --app-path      "/Applications/Cursor.app" \
+        --state-file    "$storage" \
+        --state-format  embedded \
+        --state-key     "windowsState"
+}
+
 if [[ -z "${ZSH_TEST_MODE:-}" ]]; then
     echo "✅ agents loaded"
 fi

--- a/tests/README.md
+++ b/tests/README.md
@@ -29,6 +29,7 @@ Minimal zsh test framework and test suites for this repo.
 - `test-livy.zsh`
 - `test-zeppelin.zsh`
 - `test-compat.zsh`
+- `test-electron-fix.zsh`
 
 ## Run tests
 

--- a/tests/test-electron-fix.zsh
+++ b/tests/test-electron-fix.zsh
@@ -1,0 +1,373 @@
+#!/usr/bin/env zsh
+
+ROOT_DIR="$(cd "$(dirname "${0:A}")/.." && pwd)"
+source "$ROOT_DIR/tests/test-framework.zsh"
+source "$ROOT_DIR/modules/agents.zsh"
+
+# =================================================================
+# Helpers — mock external commands for the test environment
+# =================================================================
+
+_efix_setup() {
+    local tmp
+    tmp="$(mktemp -d)"
+    local bin="$tmp/bin"
+    mkdir -p "$bin"
+
+    # Zero out sleeps in the function under test
+    export ELECTRON_FIX_KILL_DELAY=0
+    export ELECTRON_FIX_LAUNCH_DELAY=0
+
+    # Mock killall — just log
+    cat > "$bin/killall" <<'STUB'
+#!/usr/bin/env zsh
+echo "killall $*" >> "$EFIX_LOG"
+STUB
+    chmod +x "$bin/killall"
+
+    # Mock open — just log
+    cat > "$bin/open" <<'STUB'
+#!/usr/bin/env zsh
+echo "open $*" >> "$EFIX_LOG"
+STUB
+    chmod +x "$bin/open"
+
+    # Mock osascript — return configurable window count
+    cat > "$bin/osascript" <<'STUB'
+#!/usr/bin/env zsh
+echo "${EFIX_MOCK_WCOUNT:-1}"
+STUB
+    chmod +x "$bin/osascript"
+
+    export EFIX_TMP="$tmp"
+    export EFIX_LOG="$tmp/commands.log"
+    export EFIX_BIN="$bin"
+    : > "$EFIX_LOG"
+}
+
+_efix_teardown() {
+    rm -rf "$EFIX_TMP"
+    unset EFIX_TMP EFIX_LOG EFIX_BIN EFIX_MOCK_WCOUNT
+    unset ELECTRON_FIX_KILL_DELAY ELECTRON_FIX_LAUNCH_DELAY
+}
+
+# =================================================================
+# Tests — _electron_fix_window
+# =================================================================
+
+test_efix_missing_args_fails() {
+    local out
+    out="$(_electron_fix_window 2>&1)"
+    local rc=$?
+    assert_true "[[ $rc -ne 0 ]]" "should fail with no arguments"
+    assert_contains "$out" "Usage" "should print usage"
+}
+
+test_efix_standalone_writes_state_file() {
+    _efix_setup
+    local state_file="$EFIX_TMP/window-state.json"
+
+    PATH="$EFIX_BIN:/usr/bin:/bin" _electron_fix_window \
+        --app-name "TestApp" \
+        --state-file "$state_file" \
+        --state-format standalone >/dev/null 2>&1
+
+    assert_true "[[ -f '$state_file' ]]" "should create state file"
+    assert_contains "$(cat "$state_file")" "1200" "state file should contain default bounds"
+    _efix_teardown
+}
+
+test_efix_standalone_with_state_builder() {
+    _efix_setup
+    local state_file="$EFIX_TMP/window-state.json"
+
+    _test_builder() {
+        echo '{"windows":[{"id":"custom","bounds":{"x":50,"y":50,"width":800,"height":600}}]}'
+    }
+
+    PATH="$EFIX_BIN:/usr/bin:/bin" _electron_fix_window \
+        --app-name "TestApp" \
+        --state-file "$state_file" \
+        --state-format standalone \
+        --state-builder _test_builder >/dev/null 2>&1
+
+    assert_contains "$(cat "$state_file")" '"id":"custom"' "should use state builder output"
+    assert_contains "$(cat "$state_file")" "800" "should contain builder-specified width"
+
+    unfunction _test_builder
+    _efix_teardown
+}
+
+test_efix_embedded_patches_key() {
+    skip_if_missing python3
+    _efix_setup
+    local state_file="$EFIX_TMP/prefs.json"
+
+    # Seed an existing prefs file with other data
+    cat > "$state_file" <<'EOF'
+{
+  "theme": "dark",
+  "windowBounds": {"x": 9999, "y": 9999, "width": 10, "height": 10},
+  "otherSetting": true
+}
+EOF
+
+    PATH="$EFIX_BIN:/usr/bin:/bin" _electron_fix_window \
+        --app-name "TestApp" \
+        --state-file "$state_file" \
+        --state-format embedded \
+        --state-key "windowBounds" >/dev/null 2>&1
+
+    # The key should be overwritten with default bounds
+    assert_contains "$(cat "$state_file")" "1200" "embedded key should have new bounds"
+    # Other keys should be preserved
+    assert_contains "$(cat "$state_file")" '"theme": "dark"' "should preserve other keys"
+    assert_contains "$(cat "$state_file")" '"otherSetting": true' "should preserve other settings"
+    _efix_teardown
+}
+
+test_efix_embedded_requires_state_key() {
+    _efix_setup
+    local state_file="$EFIX_TMP/prefs.json"
+    echo '{}' > "$state_file"
+
+    local out
+    out="$(PATH="$EFIX_BIN:/usr/bin:/bin" _electron_fix_window \
+        --app-name "TestApp" \
+        --state-file "$state_file" \
+        --state-format embedded 2>&1)"
+    local rc=$?
+
+    assert_true "[[ $rc -ne 0 ]]" "should fail without --state-key"
+    assert_contains "$out" "state-key" "should mention missing state-key"
+    _efix_teardown
+}
+
+test_efix_embedded_missing_file_fails() {
+    _efix_setup
+
+    local out
+    out="$(PATH="$EFIX_BIN:/usr/bin:/bin" _electron_fix_window \
+        --app-name "TestApp" \
+        --state-file "$EFIX_TMP/nonexistent.json" \
+        --state-format embedded \
+        --state-key "bounds" 2>&1)"
+    local rc=$?
+
+    assert_true "[[ $rc -ne 0 ]]" "should fail when state file does not exist"
+    assert_contains "$out" "not found" "should report file not found"
+    _efix_teardown
+}
+
+test_efix_kills_app() {
+    _efix_setup
+    local state_file="$EFIX_TMP/window-state.json"
+
+    PATH="$EFIX_BIN:/usr/bin:/bin" _electron_fix_window \
+        --app-name "TestApp" \
+        --state-file "$state_file" \
+        --state-format standalone >/dev/null 2>&1
+
+    assert_contains "$(cat "$EFIX_LOG")" "killall TestApp" "should kill the app process"
+    _efix_teardown
+}
+
+test_efix_uses_process_name_override() {
+    _efix_setup
+    local state_file="$EFIX_TMP/window-state.json"
+
+    PATH="$EFIX_BIN:/usr/bin:/bin" _electron_fix_window \
+        --app-name "TestApp" \
+        --process-name "TestElectron" \
+        --state-file "$state_file" \
+        --state-format standalone >/dev/null 2>&1
+
+    assert_contains "$(cat "$EFIX_LOG")" "killall TestElectron" "should kill using process-name"
+    assert_not_contains "$(cat "$EFIX_LOG")" "killall TestApp" "should not use app-name for kill"
+    _efix_teardown
+}
+
+test_efix_removes_lock_files() {
+    _efix_setup
+    local state_file="$EFIX_TMP/window-state.json"
+    local lock1="$EFIX_TMP/.server.lock"
+    local lock2="$EFIX_TMP/SingletonLock"
+    echo "123" > "$lock1"
+    echo "456" > "$lock2"
+
+    PATH="$EFIX_BIN:/usr/bin:/bin" _electron_fix_window \
+        --app-name "TestApp" \
+        --state-file "$state_file" \
+        --state-format standalone \
+        --lock-file "$lock1" \
+        --lock-file "$lock2" >/dev/null 2>&1
+
+    assert_false "[[ -f '$lock1' ]]" "first lock file should be removed"
+    assert_false "[[ -f '$lock2' ]]" "second lock file should be removed"
+    _efix_teardown
+}
+
+test_efix_relaunches_with_app_path() {
+    _efix_setup
+    local state_file="$EFIX_TMP/window-state.json"
+    mkdir -p "$EFIX_TMP/TestApp.app"
+
+    PATH="$EFIX_BIN:/usr/bin:/bin" _electron_fix_window \
+        --app-name "TestApp" \
+        --app-path "$EFIX_TMP/TestApp.app" \
+        --state-file "$state_file" \
+        --state-format standalone >/dev/null 2>&1
+
+    assert_contains "$(cat "$EFIX_LOG")" "open $EFIX_TMP/TestApp.app" "should relaunch using app-path"
+    _efix_teardown
+}
+
+test_efix_relaunches_by_name_without_app_path() {
+    _efix_setup
+    local state_file="$EFIX_TMP/window-state.json"
+
+    PATH="$EFIX_BIN:/usr/bin:/bin" _electron_fix_window \
+        --app-name "TestApp" \
+        --state-file "$state_file" \
+        --state-format standalone >/dev/null 2>&1
+
+    assert_contains "$(cat "$EFIX_LOG")" "open -a TestApp" "should relaunch using open -a"
+    _efix_teardown
+}
+
+test_efix_reports_failure_when_no_window() {
+    _efix_setup
+    export EFIX_MOCK_WCOUNT=0
+    local state_file="$EFIX_TMP/window-state.json"
+
+    local out
+    out="$(PATH="$EFIX_BIN:/usr/bin:/bin" _electron_fix_window \
+        --app-name "TestApp" \
+        --state-file "$state_file" \
+        --state-format standalone 2>&1)"
+    local rc=$?
+
+    assert_true "[[ $rc -ne 0 ]]" "should return failure when no window appears"
+    assert_contains "$out" "no window detected" "should warn about missing window"
+    _efix_teardown
+}
+
+test_efix_creates_parent_dirs_for_state_file() {
+    _efix_setup
+    local state_file="$EFIX_TMP/nested/deep/window-state.json"
+
+    PATH="$EFIX_BIN:/usr/bin:/bin" _electron_fix_window \
+        --app-name "TestApp" \
+        --state-file "$state_file" \
+        --state-format standalone >/dev/null 2>&1
+
+    assert_true "[[ -f '$state_file' ]]" "should create parent directories and state file"
+    _efix_teardown
+}
+
+# =================================================================
+# Tests — craft_agents_fix wrapper
+# =================================================================
+
+test_craft_agents_fix_builds_state_from_config() {
+    _efix_setup
+    local craft_dir="$EFIX_TMP/.craft-agent"
+    mkdir -p "$craft_dir"
+    cat > "$craft_dir/config.json" <<'EOF'
+{
+  "workspaces": [
+    { "id": "ws-aaa", "name": "First" },
+    { "id": "ws-bbb", "name": "Second" }
+  ],
+  "activeWorkspaceId": "ws-bbb"
+}
+EOF
+
+    # Override HOME so craft_agents_fix finds our mock config
+    HOME="$EFIX_TMP" PATH="$EFIX_BIN:/usr/bin:/bin" \
+        craft_agents_fix >/dev/null 2>&1
+
+    local state
+    state="$(cat "$craft_dir/window-state.json")"
+    assert_contains "$state" "ws-bbb" "should use activeWorkspaceId"
+    assert_contains "$state" "1200" "should include bounds"
+    _efix_teardown
+}
+
+test_craft_agents_fix_falls_back_to_first_workspace() {
+    skip_if_missing python3
+    _efix_setup
+    local craft_dir="$EFIX_TMP/.craft-agent"
+    mkdir -p "$craft_dir"
+    cat > "$craft_dir/config.json" <<'EOF'
+{
+  "workspaces": [
+    { "id": "ws-fallback", "name": "Only" }
+  ],
+  "activeWorkspaceId": null
+}
+EOF
+
+    HOME="$EFIX_TMP" PATH="$EFIX_BIN:/usr/bin:/bin" \
+        craft_agents_fix >/dev/null 2>&1
+
+    assert_contains "$(cat "$craft_dir/window-state.json")" "ws-fallback" \
+        "should fall back to first workspace when active is null"
+    _efix_teardown
+}
+
+test_craft_agents_fix_removes_server_lock() {
+    _efix_setup
+    local craft_dir="$EFIX_TMP/.craft-agent"
+    mkdir -p "$craft_dir"
+    cat > "$craft_dir/config.json" <<'EOF'
+{ "workspaces": [{"id":"ws-1","name":"W"}], "activeWorkspaceId": "ws-1" }
+EOF
+    echo "999" > "$craft_dir/.server.lock"
+
+    HOME="$EFIX_TMP" PATH="$EFIX_BIN:/usr/bin:/bin" \
+        craft_agents_fix >/dev/null 2>&1
+
+    assert_false "[[ -f '$craft_dir/.server.lock' ]]" "should remove .server.lock"
+    _efix_teardown
+}
+
+# =================================================================
+# Tests — claude_desktop_fix wrapper
+# =================================================================
+
+test_claude_desktop_fix_writes_default_bounds() {
+    _efix_setup
+    local claude_dir="$EFIX_TMP/Library/Application Support/Claude"
+    mkdir -p "$claude_dir"
+
+    HOME="$EFIX_TMP" PATH="$EFIX_BIN:/usr/bin:/bin" \
+        claude_desktop_fix >/dev/null 2>&1
+
+    local state_file="$claude_dir/window-state.json"
+    assert_true "[[ -f '$state_file' ]]" "should create window-state.json"
+    assert_contains "$(cat "$state_file")" "1200" "should have default bounds"
+    _efix_teardown
+}
+
+# =================================================================
+# Registration
+# =================================================================
+
+register_test "test_efix_missing_args_fails"
+register_test "test_efix_standalone_writes_state_file"
+register_test "test_efix_standalone_with_state_builder"
+register_test "test_efix_embedded_patches_key"
+register_test "test_efix_embedded_requires_state_key"
+register_test "test_efix_embedded_missing_file_fails"
+register_test "test_efix_kills_app"
+register_test "test_efix_uses_process_name_override"
+register_test "test_efix_removes_lock_files"
+register_test "test_efix_relaunches_with_app_path"
+register_test "test_efix_relaunches_by_name_without_app_path"
+register_test "test_efix_reports_failure_when_no_window"
+register_test "test_efix_creates_parent_dirs_for_state_file"
+register_test "test_craft_agents_fix_builds_state_from_config"
+register_test "test_craft_agents_fix_falls_back_to_first_workspace"
+register_test "test_craft_agents_fix_removes_server_lock"
+register_test "test_claude_desktop_fix_writes_default_bounds"

--- a/wiki/How-To-Recipes.md
+++ b/wiki/How-To-Recipes.md
@@ -83,6 +83,17 @@ backup "feature checkpoint"
 backup_merge_main
 ```
 
+## Fix Electron App With No Visible Window
+If an Electron app (Craft Agents, Claude, VS Code, Cursor) launches but shows no window:
+```bash
+craft_agents_fix       # Craft Agents
+claude_desktop_fix     # Claude desktop
+vscode_fix             # VS Code
+cursor_fix             # Cursor
+```
+Each wrapper kills the app, resets the window-state file, relaunches, and verifies a window appeared.
+See [Module: Agents](Module-Agents#electron-app-window-repair) for details and how to add new apps.
+
 ## Run Focused Test Sets
 ```bash
 zsh run-tests.zsh --test test_settings_load_order

--- a/wiki/Module-Agents.md
+++ b/wiki/Module-Agents.md
@@ -89,6 +89,61 @@ Default attribution policy is strict:
 - `development/` - Coding helpers (empty)
 - `operations/` - Runtime tasks (empty)
 
+### Electron App Window Repair
+
+Electron apps (Craft Agents, Claude, VS Code, Cursor) sometimes launch with no visible window.
+The root cause is typically corrupt or empty window-state data.  The generic engine
+`_electron_fix_window` handles two storage patterns and provides per-app convenience wrappers.
+
+#### Generic Engine
+
+| Function | Purpose | Dependencies | Assumptions |
+|---|---|---|---|
+| `_electron_fix_window` | Kill, reset window state, relaunch, verify | `killall`, `open`, `osascript`, `python3` (embedded format only) | App installed |
+
+**Parameters:**
+
+| Flag | Required | Description |
+|---|---|---|
+| `--app-name` | Yes | Display name and default `killall` target |
+| `--state-file` | Yes | Path to window-state file |
+| `--state-format` | Yes | `standalone` (overwrite entire file) or `embedded` (patch a key in existing JSON) |
+| `--process-name` | No | Override `killall` target (e.g. `Electron` for VS Code) |
+| `--app-path` | No | Explicit `.app` bundle path; falls back to `open -a <app-name>` |
+| `--state-key` | Embedded only | JSON key to overwrite inside the file |
+| `--lock-file` | No | Extra files to remove before relaunch (repeatable) |
+| `--state-builder` | No | Shell function that prints the replacement JSON value |
+
+#### Per-App Wrappers
+
+| Function | App | State Format | Notes |
+|---|---|---|---|
+| `craft_agents_fix` | Craft Agents | standalone | Reads workspace ID from `~/.craft-agent/config.json`; removes `.server.lock` |
+| `claude_desktop_fix` | Claude desktop | standalone | Writes default bounds to `~/Library/Application Support/Claude/window-state.json` |
+| `vscode_fix` | VS Code | embedded | Patches `windowsState` in `globalStorage/storage.json` |
+| `cursor_fix` | Cursor | embedded | Same layout as VS Code |
+
+**Usage:**
+```bash
+craft_agents_fix       # Fix Craft Agents invisible window
+claude_desktop_fix     # Fix Claude desktop invisible window
+vscode_fix             # Fix VS Code invisible window
+cursor_fix             # Fix Cursor invisible window
+```
+
+**Adding a new app:** define a wrapper that calls `_electron_fix_window` with the correct flags.
+If the app needs custom state (like Craft's workspace ID), write a `_<app>_state_builder`
+function and pass it via `--state-builder`.
+
+#### Environment (testing)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `ELECTRON_FIX_KILL_DELAY` | `1` | Seconds to wait after `killall` |
+| `ELECTRON_FIX_LAUNCH_DELAY` | `3` | Seconds to wait after relaunch before verification |
+
+Set both to `0` in tests to eliminate sleep overhead.
+
 ## Notes
 - Format: `name=id|description`
 - If `fzf` is installed, both `codex_session` and `claude_session` use it for selection.


### PR DESCRIPTION
## Summary

- Merges develop into main after feat/electron-window-fix (#77)
- Adds generic Electron app window repair (`_electron_fix_window`) with wrappers for Craft Agents, Claude, VS Code, and Cursor
- 17 new tests, wiki docs, and recipe updated