### PR TITLE
chore: move zsh completion cache to $XDG_CACHE_HOME/zsh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,8 @@ node_modules/
 package.json
 package-lock.json
 
-# ZSH completion cache
+# ZSH completion cache — now written to $XDG_CACHE_HOME/zsh/
+# (see zshrc compinit block). Pattern kept to ignore stragglers.
 .zcompdump*
 
 # Editor artifacts

--- a/tests/test-zshrc-startup.zsh
+++ b/tests/test-zshrc-startup.zsh
@@ -27,4 +27,30 @@ for _m in $_archived_modules; do
     fi
 done
 
+# Completion cache must live under $XDG_CACHE_HOME/zsh, not the repo root.
+grep -q 'XDG_CACHE_HOME:=\$HOME/.cache' "$ZSHRC_FILE" || fail "missing XDG_CACHE_HOME default"
+grep -q '_zcompdump="\$XDG_CACHE_HOME/zsh/zcompdump-' "$ZSHRC_FILE" \
+  || fail "_zcompdump path should be rooted in \$XDG_CACHE_HOME/zsh/"
+grep -q 'compinit -d "\$_zcompdump"' "$ZSHRC_FILE" \
+  || fail "compinit must target \$_zcompdump with -d (rebuild path)"
+grep -q 'compinit -C -d "\$_zcompdump"' "$ZSHRC_FILE" \
+  || fail "compinit fast path must target \$_zcompdump with -C -d"
+
+# Behavioral check: executing just the compinit block writes under $XDG_CACHE_HOME/zsh,
+# not into $HOME. Extract lines between the compinit comment and the `unset _zcompdump`
+# marker, then run them in a subshell with scratch HOME/XDG.
+_cache_tmp="$(mktemp -d 2>/dev/null)" || fail "mktemp failed"
+_home_tmp="$(mktemp -d 2>/dev/null)" || fail "mktemp failed"
+trap 'rm -rf "$_cache_tmp" "$_home_tmp"' EXIT
+_block="$(awk '/^# Initialize completion system/,/^unset _zcompdump/' "$ZSHRC_FILE")"
+[[ -n "$_block" ]] || fail "could not extract compinit block from zshrc"
+HOME="$_home_tmp" XDG_CACHE_HOME="$_cache_tmp" \
+  zsh -c "$_block" >/dev/null 2>&1 || fail "compinit block errored under scratch HOME/XDG"
+_dumps=("$_cache_tmp"/zsh/zcompdump-*(N))
+(( ${#_dumps} > 0 )) \
+  || fail "expected zcompdump under \$XDG_CACHE_HOME/zsh/, found none"
+_stragglers=("$_home_tmp"/.zcompdump*(N))
+(( ${#_stragglers} == 0 )) \
+  || fail "compinit block leaked .zcompdump* into \$HOME"
+
 print -- "test-zshrc-startup: ok"

--- a/zshrc
+++ b/zshrc
@@ -75,13 +75,19 @@ ZSH_THEME="powerlevel10k/powerlevel10k"
 plugins=(git)
 
 
-# Initialize completion system (rebuild dump at most once per day)
+# Initialize completion system (rebuild dump at most once per day).
+# Cache lives under $XDG_CACHE_HOME/zsh/ (not the repo root). Keyed by host
+# and zsh version so mixed-host setups don't step on each other.
+: "${XDG_CACHE_HOME:=$HOME/.cache}"
+[[ -d "$XDG_CACHE_HOME/zsh" ]] || mkdir -p "$XDG_CACHE_HOME/zsh"
 autoload -Uz compinit
-if [[ -f ~/.zcompdump && $(date +'%j') == $(stat -f '%Sm' -t '%j' ~/.zcompdump 2>/dev/null) ]]; then
-    compinit -C  # fast: skip security check, use cached dump
+_zcompdump="$XDG_CACHE_HOME/zsh/zcompdump-${HOST}-${ZSH_VERSION}"
+if [[ -f "$_zcompdump" && $(date +'%j') == $(stat -f '%Sm' -t '%j' "$_zcompdump" 2>/dev/null) ]]; then
+    compinit -C -d "$_zcompdump"  # fast: skip security check, use cached dump
 else
-    compinit      # full rebuild
+    compinit -d "$_zcompdump"      # full rebuild
 fi
+unset _zcompdump
 
 # Warp is sensitive to noisy, probe-heavy interactive startup. Default it to a
 # lighter path unless explicitly overridden.

--- a/zshrc
+++ b/zshrc
@@ -82,12 +82,19 @@ plugins=(git)
 [[ -d "$XDG_CACHE_HOME/zsh" ]] || mkdir -p "$XDG_CACHE_HOME/zsh"
 autoload -Uz compinit
 _zcompdump="$XDG_CACHE_HOME/zsh/zcompdump-${HOST}-${ZSH_VERSION}"
-if [[ -f "$_zcompdump" && $(date +'%j') == $(stat -f '%Sm' -t '%j' "$_zcompdump" 2>/dev/null) ]]; then
+# stat -f %m is BSD/macOS; stat -c %Y is GNU/Linux. Fall through both.
+_zcompdump_mtime=0
+if [[ -f "$_zcompdump" ]]; then
+    _zcompdump_mtime="$(stat -f %m "$_zcompdump" 2>/dev/null \
+                       || stat -c %Y "$_zcompdump" 2>/dev/null \
+                       || echo 0)"
+fi
+if (( _zcompdump_mtime > 0 )) && (( $(date +%s) - _zcompdump_mtime < 86400 )); then
     compinit -C -d "$_zcompdump"  # fast: skip security check, use cached dump
 else
     compinit -d "$_zcompdump"      # full rebuild
 fi
-unset _zcompdump
+unset _zcompdump _zcompdump_mtime
 
 # Warp is sensitive to noisy, probe-heavy interactive startup. Default it to a
 # lighter path unless explicitly overridden.


### PR DESCRIPTION
## Summary
- Completion dump now lives at `$XDG_CACHE_HOME/zsh/zcompdump-<host>-<version>` instead of the repo root.
- Keyed by host + zsh version — useful if you share `~/.config/zsh` across machines.
- Deleted the three stale `.zcompdump*` files that had been sitting in the repo root.
- Updated `.gitignore` comment to explain the move.

## Test plan
- [x] `ZSH_FORCE_FULL_INIT=1 zsh -i -c ...` creates `~/.cache/zsh/zcompdump-<host>-<ver>`
- [x] No `.zcompdump*` remain at repo root
- [ ] Tab completion still works in a fresh interactive shell
- [ ] CI green

Part of #79, closes #81.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Move ZSH completion cache from the home dir to XDG_CACHE_HOME/zsh (defaults to ~/.cache) for better standards compliance and file organization.
* **Bug Fixes**
  * Ensure completion cache is host- and zsh-version-specific to avoid cross-host/version conflicts.
* **Tests**
  * Add tests verifying cache location, compinit behavior (fast vs full rebuild), and that no .zcompdump files are left in HOME.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->