### PR TITLE
perf: disable unused Oh-My-Zsh overhead at startup

### DIFF
--- a/tests/test-zshrc-startup.zsh
+++ b/tests/test-zshrc-startup.zsh
@@ -18,6 +18,21 @@ grep -q 'ZSH_AUTO_RECOVER_MODE:=auto' "$ZSHRC_FILE" || fail "missing auto-recove
 grep -q 'if _zsh_should_auto_recover_services; then' "$ZSHRC_FILE" || fail "missing guarded auto-recover call"
 grep -q 'if _zsh_show_full_startup_banner; then' "$ZSHRC_FILE" || fail "missing guarded banner call"
 
+# OMZ overhead knobs — all must be set before sourcing oh-my-zsh.sh.
+grep -q "zstyle ':omz:update' mode disabled" "$ZSHRC_FILE" \
+  || fail "missing OMZ auto-update disable"
+grep -q 'ZSH_DISABLE_COMPFIX=true' "$ZSHRC_FILE" \
+  || fail "missing ZSH_DISABLE_COMPFIX=true"
+grep -q 'DISABLE_MAGIC_FUNCTIONS=true' "$ZSHRC_FILE" \
+  || fail "missing DISABLE_MAGIC_FUNCTIONS=true"
+grep -q 'DISABLE_AUTO_TITLE=true' "$ZSHRC_FILE" \
+  || fail "missing DISABLE_AUTO_TITLE=true"
+# Order matters: knobs must appear before the oh-my-zsh.sh source line.
+_knob_line=$(grep -n "zstyle ':omz:update' mode disabled" "$ZSHRC_FILE" | head -1 | cut -d: -f1)
+_omz_line=$(grep -n 'source "\$ZSH/oh-my-zsh.sh"' "$ZSHRC_FILE" | head -1 | cut -d: -f1)
+[[ -n "$_knob_line" && -n "$_omz_line" && "$_knob_line" -lt "$_omz_line" ]] \
+  || fail "OMZ knobs must appear before the oh-my-zsh.sh source line"
+
 # Archived modules must not be loaded from zshrc.
 _archived_modules=("$ROOT_DIR"/modules/archived/*.zsh(N:t:r))
 for _m in $_archived_modules; do

--- a/zshrc
+++ b/zshrc
@@ -74,6 +74,16 @@ export ZSH="$HOME/.dotfiles/oh-my-zsh"
 ZSH_THEME="powerlevel10k/powerlevel10k"
 plugins=(git)
 
+# OMZ overhead we don't use.
+# - auto-update: run manually via `omz update` instead of on every shell.
+# - COMPFIX: compinit security check is already handled above.
+# - MAGIC_FUNCTIONS: bracketed-paste handlers we don't rely on.
+# - AUTO_TITLE: we set our own terminal titles elsewhere.
+zstyle ':omz:update' mode disabled
+ZSH_DISABLE_COMPFIX=true
+DISABLE_MAGIC_FUNCTIONS=true
+DISABLE_AUTO_TITLE=true
+
 
 # Initialize completion system (rebuild dump at most once per day).
 # Cache lives under $XDG_CACHE_HOME/zsh/ (not the repo root). Keyed by host


### PR DESCRIPTION
## Summary
- Adds four OMZ knobs before sourcing `oh-my-zsh.sh`: disable auto-update, `ZSH_DISABLE_COMPFIX`, `DISABLE_MAGIC_FUNCTIONS`, `DISABLE_AUTO_TITLE`.
- Test added: structural checks in `test-zshrc-startup.zsh` assert all four knobs exist and appear **before** the `oh-my-zsh.sh` source line.

## Measurement

Protocol: `time ZSH_FORCE_FULL_INIT=1 ZSH_STATUS_BANNER_MODE=off ZSH_AUTO_RECOVER_MODE=off zsh -i -c exit`, 5 runs, `total` column.

| | Baseline (main) | After |
|---|---|---|
| Median | 513ms | 487ms |
| Range | 488–680ms | 481–493ms |

Saving is modest (~25ms median) but there's also a clear variance reduction — no more outlier first-run hit from the OMZ update probe.

## Manual update workflow

Auto-update is off. Use `omz update` explicitly when you want to pick up OMZ changes.

## Test plan
- [x] `zsh tests/test-zshrc-startup.zsh` passes
- [x] Interactive shell still works end-to-end (P10K renders, git aliases work)
- [ ] CI green

Part of #79, closes #83.