### PR TITLE
feat: enable low-cost Oh-My-Zsh plugins

### DIFF
--- a/tests/test-zshrc-startup.zsh
+++ b/tests/test-zshrc-startup.zsh
@@ -33,6 +33,22 @@ _omz_line=$(grep -n 'source "\$ZSH/oh-my-zsh.sh"' "$ZSHRC_FILE" | head -1 | cut 
 [[ -n "$_knob_line" && -n "$_omz_line" && "$_knob_line" -lt "$_omz_line" ]] \
   || fail "OMZ knobs must appear before the oh-my-zsh.sh source line"
 
+# Low-cost OMZ plugin enrichment. Each plugin should appear in plugins=(...)
+# and none of the deliberately-excluded heavy ones should leak in.
+for _p in git gitfast gh fzf sudo copybuffer copypath copyfile history-substring-search aliases brew; do
+    grep -qE "^\s+${_p}\b" "$ZSHRC_FILE" \
+        || fail "expected OMZ plugin '${_p}' to be enabled"
+done
+# command-not-found is intentionally excluded (brew init is slow).
+grep -qE "^\s+command-not-found\b" "$ZSHRC_FILE" \
+    && fail "command-not-found must not be in plugins=(...) — too slow at startup"
+
+# history-substring-search requires arrow-key bindings after OMZ loads.
+grep -q "bindkey '\^\[\[A' history-substring-search-up" "$ZSHRC_FILE" \
+    || fail "history-substring-search up-arrow binding missing"
+grep -q "bindkey '\^\[\[B' history-substring-search-down" "$ZSHRC_FILE" \
+    || fail "history-substring-search down-arrow binding missing"
+
 # Archived modules must not be loaded from zshrc.
 _archived_modules=("$ROOT_DIR"/modules/archived/*.zsh(N:t:r))
 for _m in $_archived_modules; do

--- a/zshrc
+++ b/zshrc
@@ -72,7 +72,21 @@ fi
 # Oh-My-Zsh setup
 export ZSH="$HOME/.dotfiles/oh-my-zsh"
 ZSH_THEME="powerlevel10k/powerlevel10k"
-plugins=(git)
+plugins=(
+    git                       # canonical alias set + helpers
+    gitfast                   # upstream git completion (faster than OMZ's default)
+    gh                        # gh CLI completion
+    fzf                       # Ctrl-R history, Ctrl-T file, Alt-C dir (fzf keybinds)
+    sudo                      # double-ESC prepends sudo to the current line
+    copybuffer                # Ctrl-O copies current command-line to clipboard
+    copypath                  # `copypath` copies $PWD to clipboard
+    copyfile                  # `copyfile <f>` copies contents to clipboard
+    history-substring-search  # up-arrow filters history by typed prefix
+    aliases                   # `aliases` command lists aliases by group
+    brew
+    # command-not-found intentionally excluded: its brew-based init
+    # adds ~150ms to startup. Revisit via zsh-defer (Stage 6).
+)
 
 # OMZ overhead we don't use.
 # - auto-update: run manually via `omz update` instead of on every shell.
@@ -150,6 +164,12 @@ zmodload zsh/compctl 2>/dev/null
 # Load Oh-My-Zsh
 if [[ -f "$ZSH/oh-my-zsh.sh" ]]; then
     source "$ZSH/oh-my-zsh.sh"
+
+    # Bind history-substring-search to arrow keys (plugin must be loaded first).
+    if (( ${+functions[history-substring-search-up]} )); then
+        bindkey '^[[A' history-substring-search-up
+        bindkey '^[[B' history-substring-search-down
+    fi
 fi
 
 # =================================================================


### PR DESCRIPTION
## Summary
- Expands `plugins=(...)` from just `git` to a set of bundled OMZ plugins that are each either free or net-positive on startup.
- Wires arrow-key bindings for `history-substring-search` after OMZ loads.
- Tests added to guard: each expected plugin enabled, `command-not-found` explicitly *disabled*, history-substring-search keybindings present.

## Added plugins
`gitfast`, `gh`, `fzf`, `sudo`, `copybuffer`, `copypath`, `copyfile`, `history-substring-search`, `aliases`, `brew`.

## Deliberately excluded
`command-not-found` — on macOS it runs `brew command-not-found-init`, which profiled at ~150ms of startup by itself. Deferred to Stage 6 via `zsh-defer`.

## Measurement

Protocol: `time ZSH_FORCE_FULL_INIT=1 ZSH_STATUS_BANNER_MODE=off ZSH_AUTO_RECOVER_MODE=off zsh -i -c exit`, 5 runs, `total` column.

| | Stage 4 baseline | Stage 5 after |
|---|---|---|
| Median | 487ms | **447ms** |
| Range | 481–493ms | 445–463ms |

Startup got **faster** despite adding 10 plugins — `gitfast` replacing OMZ's default git completion more than paid for the rest.

## Test plan
- [x] `zsh tests/test-zshrc-startup.zsh` passes
- [x] Ctrl-R opens fzf history (smoke-tested)
- [x] Double-ESC prepends sudo (smoke-tested)
- [x] `aliases` lists alias groups (smoke-tested)
- [x] Up-arrow filters history by typed prefix (smoke-tested)
- [ ] CI green

Part of #79, closes #84.