### PR TITLE
feat: add third-party zsh plugins with zsh-defer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -166,7 +166,24 @@ install_oh_my_zsh() {
         git clone --depth=1 https://github.com/romkatv/powerlevel10k.git \
             "$HOME/.dotfiles/oh-my-zsh/custom/themes/powerlevel10k"
     fi
-    
+
+    # Install third-party OMZ custom plugins referenced from zshrc.
+    local plugins_dir="$HOME/.dotfiles/oh-my-zsh/custom/plugins"
+    mkdir -p "$plugins_dir"
+    local repo name
+    for repo in \
+        romkatv/zsh-defer \
+        zsh-users/zsh-autosuggestions \
+        zsh-users/zsh-syntax-highlighting \
+        zsh-users/zsh-completions
+    do
+        name="${repo##*/}"
+        if [ ! -d "$plugins_dir/$name" ]; then
+            print_info "Installing $name..."
+            git clone --depth=1 "https://github.com/$repo.git" "$plugins_dir/$name"
+        fi
+    done
+
     print_success "Oh-My-Zsh installed"
 }
 

--- a/tests/test-zshrc-startup.zsh
+++ b/tests/test-zshrc-startup.zsh
@@ -43,6 +43,24 @@ done
 grep -qE "^\s+command-not-found\b" "$ZSHRC_FILE" \
     && fail "command-not-found must not be in plugins=(...) — too slow at startup"
 
+# Third-party plugins + deferred loading.
+for _p in zsh-defer zsh-autosuggestions zsh-syntax-highlighting zsh-completions; do
+    grep -qE "^\s+${_p}\b" "$ZSHRC_FILE" \
+        || fail "expected third-party plugin '${_p}' to be enabled"
+done
+# zsh-defer must be the first plugin so later plugins can use it.
+_first_plugin=$(awk '/^plugins=\(/{flag=1; next} flag && /^[ \t]+[a-z]/{print $1; exit}' "$ZSHRC_FILE")
+[[ "$_first_plugin" == "zsh-defer" ]] \
+    || fail "zsh-defer must be the first plugin (got: '${_first_plugin}')"
+# zsh-syntax-highlighting must be the last plugin.
+_last_plugin=$(awk '/^plugins=\(/{flag=1; next} /^\)/{flag=0} flag && /^[ \t]+[a-z]/{p=$1} END{print p}' "$ZSHRC_FILE")
+[[ "$_last_plugin" == "zsh-syntax-highlighting" ]] \
+    || fail "zsh-syntax-highlighting must be the last plugin (got: '${_last_plugin}')"
+
+# command-not-found must be loaded via zsh-defer (not inline).
+grep -q "zsh-defer source .*command-not-found" "$ZSHRC_FILE" \
+    || fail "command-not-found should be deferred via zsh-defer"
+
 # history-substring-search requires arrow-key bindings after OMZ loads.
 grep -q "bindkey '\^\[\[A' history-substring-search-up" "$ZSHRC_FILE" \
     || fail "history-substring-search up-arrow binding missing"

--- a/zshrc
+++ b/zshrc
@@ -73,6 +73,7 @@ fi
 export ZSH="$HOME/.dotfiles/oh-my-zsh"
 ZSH_THEME="powerlevel10k/powerlevel10k"
 plugins=(
+    zsh-defer                 # must be first: defers other plugin work past first prompt
     git                       # canonical alias set + helpers
     gitfast                   # upstream git completion (faster than OMZ's default)
     gh                        # gh CLI completion
@@ -84,8 +85,9 @@ plugins=(
     history-substring-search  # up-arrow filters history by typed prefix
     aliases                   # `aliases` command lists aliases by group
     brew
-    # command-not-found intentionally excluded: its brew-based init
-    # adds ~150ms to startup. Revisit via zsh-defer (Stage 6).
+    zsh-completions           # extra completions OMZ doesn't ship
+    zsh-autosuggestions       # fish-style greyed suggestions as you type
+    zsh-syntax-highlighting   # MUST BE LAST: colorizes commands as valid/invalid
 )
 
 # OMZ overhead we don't use.
@@ -169,6 +171,14 @@ if [[ -f "$ZSH/oh-my-zsh.sh" ]]; then
     if (( ${+functions[history-substring-search-up]} )); then
         bindkey '^[[A' history-substring-search-up
         bindkey '^[[B' history-substring-search-down
+    fi
+
+    # Deferred completion loads — heavy inits that don't need to block first prompt.
+    # command-not-found runs `brew command-not-found-init` on macOS (~150ms), so we
+    # source its plugin file via zsh-defer rather than listing it in plugins=(...).
+    if (( ${+functions[zsh-defer]} )); then
+        [[ -f "$ZSH/plugins/command-not-found/command-not-found.plugin.zsh" ]] \
+            && zsh-defer source "$ZSH/plugins/command-not-found/command-not-found.plugin.zsh"
     fi
 fi
 


### PR DESCRIPTION
## Summary
- Adds four third-party OMZ custom plugins: `zsh-defer`, `zsh-autosuggestions`, `zsh-syntax-highlighting`, `zsh-completions`.
- Correct ordering enforced: `zsh-defer` first, `zsh-syntax-highlighting` last (per upstream).
- `command-not-found` is now loaded via `zsh-defer source ...` rather than `plugins=(...)`, keeping its ~150ms brew init off the first-prompt path.
- `install.sh` extended to clone the four plugins on fresh setup.
- Tests guard plugin presence, ordering, and deferred loading.

## Measurement

Protocol: `time ZSH_FORCE_FULL_INIT=1 ZSH_STATUS_BANNER_MODE=off ZSH_AUTO_RECOVER_MODE=off zsh -i -c exit`, 5 runs, `total` column.

| | Stage 5 baseline | Stage 6 after |
|---|---|---|
| Median | 447ms | **463ms** |
| Range | 445–463ms | 451–894ms |

+16ms median for three full plugins is a good trade. The 894ms outlier was a cold-cache first run; subsequent runs are 451-484ms.

## Test plan
- [x] `zsh tests/test-zshrc-startup.zsh` passes
- [x] Greyed autosuggestions appear as you type (smoke-tested)
- [x] Commands colored red (invalid) or green (valid) (smoke-tested)
- [x] `zsh-defer` functions are defined
- [x] `command-not-found` fires for unknown commands after first prompt
- [ ] CI green

Part of #79, closes #85.