### PR TITLE
feat: git-extras plugin + git alias cheat sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,12 @@ git pull origin main
 exec zsh
 ```
 
+### **Git aliases & extras**
+
+For a curated cheat sheet of OMZ git plugin aliases plus `git-extras`
+subcommands worth knowing, see [docs/git-aliases.md](docs/git-aliases.md).
+Requires `brew install git-extras` to get the `git-*` subcommands.
+
 ### **Troubleshooting Installation**
 
 If you encounter issues, see [TROUBLESHOOTING.md](TROUBLESHOOTING.md):

--- a/docs/git-aliases.md
+++ b/docs/git-aliases.md
@@ -1,0 +1,97 @@
+# Git aliases & extras cheat sheet
+
+Aliases come from the Oh-My-Zsh `git` plugin (auto-loaded). The `git-*`
+subcommands come from `git-extras` (install: `brew install git-extras`).
+
+Grouped by how often you'll reach for them. When in doubt:
+`alias | grep '^g'` lists every alias starting with `g`, or use the
+`aliases` plugin's grouped view: `aliases -s git`.
+
+---
+
+## Daily drivers (OMZ `git` plugin)
+
+| Alias | Expands to | Why |
+|---|---|---|
+| `gst` | `git status` | Fastest status peek |
+| `gd` | `git diff` | Working tree diff |
+| `gdca` | `git diff --cached` | What's staged |
+| `gaa` | `git add --all` | Stage everything |
+| `gcmsg "msg"` | `git commit -m "msg"` | Quick commit |
+| `gca` | `git commit -v -a` | Commit all tracked, verbose |
+| `gcan!` | `git commit -v -a --no-edit --amend` | Amend last commit silently |
+| `gco <b>` | `git checkout <b>` | Switch branch |
+| `gcb <b>` | `git checkout -b <b>` | New branch |
+| `gl` | `git pull` | Pull current branch |
+| `gp` | `git push` | Push current branch |
+| `gpsup` | `git push --set-upstream origin $(current_branch)` | First push of a new branch |
+| `ggpur` | `git pull origin $(current_branch)` | Pull from matching upstream |
+
+## History & log
+
+| Alias | Expands to | Why |
+|---|---|---|
+| `glog` | `git log --oneline --decorate --graph` | Readable oneline log |
+| `glola` | `git log --graph --abbrev-commit --decorate --all --pretty=format:'%C(bold blue)%h%Creset...'` | Beautiful all-branches graph |
+| `glol` | `glola` but current branch only | Focused history |
+| `gbl` | `git blame -b -w` | Ignore whitespace + boundary |
+
+## Rebasing & history surgery
+
+| Alias | Expands to | Why |
+|---|---|---|
+| `grb` | `git rebase` | Base |
+| `grbi` | `git rebase -i` | Interactive rebase |
+| `grba` | `git rebase --abort` | Escape hatch |
+| `grbc` | `git rebase --continue` | After conflicts |
+| `gwip` | Stage + commit as `--wip--` | Park in-progress work |
+| `gunwip` | Undo a `gwip` | Resume |
+
+## Stash
+
+| Alias | Expands to |
+|---|---|
+| `gsta` | `git stash push` |
+| `gstp` | `git stash pop` |
+| `gstl` | `git stash list` |
+| `gstd` | `git stash drop` |
+
+## Inspection shortcuts
+
+| Alias | Expands to |
+|---|---|
+| `gsta` | `git stash push` |
+| `gcl` | `git clone --recurse-submodules` |
+| `grh` | `git reset` |
+| `grhh` | `git reset --hard` |
+| `gclean` | `git clean -id` |
+
+---
+
+## `git-extras` subcommands worth knowing
+
+Install: `brew install git-extras` (already required by Stage 7).
+
+| Command | What it does |
+|---|---|
+| `git summary` | Project stats: first/last commit, authors, commit count |
+| `git undo` | Undo the last commit (keeps changes staged) |
+| `git ignore <pattern>` | Append to `.gitignore` from the CLI |
+| `git info` | Condensed repo overview (remotes, local branches, last commit) |
+| `git delete-merged-branches` | Prune branches already merged into default |
+| `git changelog` | Scaffold/append to CHANGELOG.md from commit messages |
+| `git effort` | Commit count per file — find churn hotspots |
+| `git count` | Total commits |
+| `git alias` | Define a git alias without editing .gitconfig |
+
+Run `git <TAB>` to see completion for all 60+ subcommands.
+
+---
+
+## When to use which
+
+- **Reading code / PR review:** `gst`, `gd`, `gdca`, `glola`
+- **Starting a change:** `gcb feature/x`, then `gaa && gcmsg "..."`, then `gpsup`
+- **Rebasing:** `grbi HEAD~5`, with `grba` / `grbc` as needed
+- **Undoing:** `gcan!` (amend) or `git undo` (from git-extras) — reach for both before `grhh`
+- **Understanding a repo for the first time:** `git summary`, `git info`, `glola`

--- a/tests/test-zshrc-startup.zsh
+++ b/tests/test-zshrc-startup.zsh
@@ -61,6 +61,13 @@ _last_plugin=$(awk '/^plugins=\(/{flag=1; next} /^\)/{flag=0} flag && /^[ \t]+[a
 grep -q "zsh-defer source .*command-not-found" "$ZSHRC_FILE" \
     || fail "command-not-found should be deferred via zsh-defer"
 
+# git-extras plugin enabled.
+grep -qE "^\s+git-extras\b" "$ZSHRC_FILE" \
+    || fail "expected OMZ plugin 'git-extras' to be enabled"
+# Cheat sheet shipped.
+[[ -f "$ROOT_DIR/docs/git-aliases.md" ]] \
+    || fail "docs/git-aliases.md cheat sheet missing"
+
 # history-substring-search requires arrow-key bindings after OMZ loads.
 grep -q "bindkey '\^\[\[A' history-substring-search-up" "$ZSHRC_FILE" \
     || fail "history-substring-search up-arrow binding missing"

--- a/zshrc
+++ b/zshrc
@@ -75,6 +75,7 @@ ZSH_THEME="powerlevel10k/powerlevel10k"
 plugins=(
     zsh-defer                 # must be first: defers other plugin work past first prompt
     git                       # canonical alias set + helpers
+    git-extras                # completion for 60+ git-* subcommands (needs `brew install git-extras`)
     gitfast                   # upstream git completion (faster than OMZ's default)
     gh                        # gh CLI completion
     fzf                       # Ctrl-R history, Ctrl-T file, Alt-C dir (fzf keybinds)


### PR DESCRIPTION
## Summary
- Enables the `git-extras` OMZ plugin (completion for 60+ `git-*` subcommands).
- Ships `docs/git-aliases.md`: curated OMZ git-plugin alias cheat sheet + git-extras subcommands.
- Links the cheat sheet from `README.md`.
- Tests guard: plugin enabled, cheat sheet exists.

## Dependency
`brew install git-extras` — adds ~55ms startup cost. Accepted; can move behind `zsh-defer` later if it becomes annoying.

## Measurement
| | Stage 6 | Stage 7 |
|---|---|---|
| Median | 463ms | 520ms |

## Test plan
- [x] `zsh tests/test-zshrc-startup.zsh` passes
- [x] `git summary`, `git info`, `git undo` work (smoke-tested)
- [x] `git <TAB>` shows extras subcommands
- [ ] CI green

Part of #79, closes #86.