### PR TITLE
fix(ci): skip Mirror workflow on the backup copy

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   mirror:
+    # This workflow file is force-pushed to the backup repo as part of mirroring.
+    # Only run on the source repo so the mirrored copy doesn't loop back on itself.
+    if: github.repository == 'dheerajchand/siege_analytics_zshrc'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Problem
Every successful mirror from \`siege_analytics_zshrc\` → \`zshrc_backups\` was triggering the same \`mirror.yml\` workflow on the backup repo (because the workflow file itself gets mirrored). The backup repo lacks \`BACKUP_DEPLOY_KEY\` and can't push to itself, so GitHub emailed a failure for every successful source-repo push.

## Fix
Add \`if: github.repository == 'dheerajchand/siege_analytics_zshrc'\` to the \`mirror\` job. The mirrored copy in \`zshrc_backups\` becomes a no-op; only the source repo actually runs the push.

## Test plan
- [x] Guard syntax valid YAML
- [ ] CI green
- [ ] After merge: next mirror run on \`zshrc_backups\` skips (logs "Mirror" as skipped) instead of failing

No issue — discovered from email noise today.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced repository mirroring reliability with conditional execution logic to prevent unintended operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->