### PR TITLE
test: add startup-time budget test

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -16,6 +16,7 @@ Minimal zsh test framework and test suites for this repo.
 - `test-banner.zsh`
 - `test-utils.zsh`
 - `test-zshrc-startup.zsh`
+- `test-startup-budget.zsh`
 - `test-backup.zsh`
 - `test-database.zsh`
 - `test-docker.zsh`

--- a/tests/test-startup-budget.zsh
+++ b/tests/test-startup-budget.zsh
@@ -1,0 +1,71 @@
+#!/usr/bin/env zsh
+# Startup-time budget test.
+#
+# Runs `zsh -i -c exit` N times, computes the median wall-clock time,
+# and fails if it exceeds ZSH_STARTUP_BUDGET_MS. Uses deterministic env:
+#   ZSH_FORCE_FULL_INIT=1         — skip non-TTY fast path
+#   ZSH_STATUS_BANNER_MODE=off    — skip heavy status banner
+#   ZSH_AUTO_RECOVER_MODE=off     — skip service auto-recovery
+#
+# Budget can be overridden for local debugging:
+#   ZSH_STARTUP_BUDGET_MS=1500 zsh tests/test-startup-budget.zsh
+#
+# CI skips the test entirely if SKIP_STARTUP_BUDGET=1 (escape hatch for
+# known-slow transient CI environments).
+
+set -euo pipefail
+
+ROOT_DIR="${0:A:h:h}"
+
+fail() {
+    print -u2 -- "FAIL: $1"
+    exit 1
+}
+
+if [[ "${SKIP_STARTUP_BUDGET:-0}" == "1" ]]; then
+    print -- "test-startup-budget: skipped (SKIP_STARTUP_BUDGET=1)"
+    exit 0
+fi
+
+# Budget chosen to catch real regressions without being flaky. Local
+# measurement on a warm shell runs ~500ms; cold-cache first samples can
+# hit >1s. The first run is discarded as warm-up; median is taken over
+# the remaining samples.
+: "${ZSH_STARTUP_BUDGET_MS:=2500}"
+: "${ZSH_STARTUP_RUNS:=6}"  # 1 warm-up + 5 measured
+
+# High-resolution wall-clock via $EPOCHREALTIME (seconds.microseconds).
+zmodload zsh/datetime 2>/dev/null || fail "zsh/datetime module unavailable"
+
+typeset -a samples
+for (( i = 1; i <= ZSH_STARTUP_RUNS; i++ )); do
+    local t0="$EPOCHREALTIME"
+    ZSH_FORCE_FULL_INIT=1 \
+        ZSH_STATUS_BANNER_MODE=off \
+        ZSH_AUTO_RECOVER_MODE=off \
+        zsh -i -c exit >/dev/null 2>&1
+    local t1="$EPOCHREALTIME"
+    # Whole-millisecond wall-clock delta (integer ms).
+    local ms=$(( (t1 - t0) * 1000 ))
+    ms=${ms%.*}
+    samples+=("$ms")
+done
+
+# Discard the first sample as warm-up; take the median of the rest.
+typeset -a measured
+measured=("${(@)samples[2,-1]}")
+typeset -a sorted
+sorted=(${(on)measured})
+local n=${#sorted}
+local mid_idx=$(( (n + 1) / 2 ))
+local median="${sorted[$mid_idx]}"
+
+print -- "startup samples (ms): ${samples[*]}   (first = warm-up, discarded)"
+print -- "sorted (measured):    ${sorted[*]}"
+print -- "median:               ${median}ms  (budget: ${ZSH_STARTUP_BUDGET_MS}ms)"
+
+if (( median > ZSH_STARTUP_BUDGET_MS )); then
+    fail "startup median ${median}ms exceeds budget ${ZSH_STARTUP_BUDGET_MS}ms"
+fi
+
+print -- "test-startup-budget: ok"

--- a/tests/test-startup-budget.zsh
+++ b/tests/test-startup-budget.zsh
@@ -3,41 +3,37 @@
 #
 # Runs `zsh -i -c exit` several times, computes the median wall-clock time
 # (excluding a warm-up sample), and fails if it exceeds ZSH_STARTUP_BUDGET_MS.
-# Uses deterministic env:
+#
+# Deterministic env:
 #   ZSH_FORCE_FULL_INIT=1         — skip non-TTY fast path
 #   ZSH_STATUS_BANNER_MODE=off    — skip heavy status banner
 #   ZSH_AUTO_RECOVER_MODE=off     — skip service auto-recovery
 #
 # Overrides:
-#   ZSH_STARTUP_BUDGET_MS=1500 zsh tests/test-startup-budget.zsh
-#   SKIP_STARTUP_BUDGET=1 (skips entirely — escape hatch for flaky CI)
+#   ZSH_STARTUP_BUDGET_MS (default 2500)
+#   ZSH_STARTUP_RUNS      (default 6 — 1 warm-up + 5 measured)
+#   SKIP_STARTUP_BUDGET=1  — skip the test entirely
 
-# The test runner sources this file; everything lives inside a function so
-# that `local` is legal and `return` doesn't abort the whole test suite.
-_test_startup_budget() {
-    emulate -L zsh
-    setopt errexit nounset pipefail
+ROOT_DIR="$(cd "$(dirname "${0:A}")/.." && pwd)"
+source "$ROOT_DIR/tests/test-framework.zsh"
 
+test_startup_budget_under_cap() {
     if [[ "${SKIP_STARTUP_BUDGET:-0}" == "1" ]]; then
-        print -- "test-startup-budget: skipped (SKIP_STARTUP_BUDGET=1)"
+        TEST_SKIP=1
         return 0
     fi
 
-    # Budget chosen to catch real regressions without being flaky. Local
-    # measurement on a warm shell runs ~500ms; cold-cache first samples can
-    # hit >1s. The first run is discarded as warm-up; median is taken over
-    # the remaining samples.
-    : "${ZSH_STARTUP_BUDGET_MS:=2500}"
-    : "${ZSH_STARTUP_RUNS:=6}"  # 1 warm-up + 5 measured
+    local budget="${ZSH_STARTUP_BUDGET_MS:-2500}"
+    local runs="${ZSH_STARTUP_RUNS:-6}"
 
     zmodload zsh/datetime 2>/dev/null || {
-        print -u2 -- "FAIL: zsh/datetime module unavailable"
+        _print_fail "zsh/datetime module unavailable"
         return 1
     }
 
     local -a samples
     local i t0 t1 ms
-    for (( i = 1; i <= ZSH_STARTUP_RUNS; i++ )); do
+    for (( i = 1; i <= runs; i++ )); do
         t0="$EPOCHREALTIME"
         ZSH_FORCE_FULL_INIT=1 \
             ZSH_STATUS_BANNER_MODE=off \
@@ -49,7 +45,7 @@ _test_startup_budget() {
         samples+=("$ms")
     done
 
-    # Discard the first sample as warm-up; take the median of the rest.
+    # Discard the first sample as warm-up; median over the rest.
     local -a measured sorted
     measured=("${(@)samples[2,-1]}")
     sorted=(${(on)measured})
@@ -57,29 +53,14 @@ _test_startup_budget() {
     local mid_idx=$(( (n + 1) / 2 ))
     local median="${sorted[$mid_idx]}"
 
-    print -- "startup samples (ms): ${samples[*]}   (first = warm-up, discarded)"
-    print -- "sorted (measured):    ${sorted[*]}"
-    print -- "median:               ${median}ms  (budget: ${ZSH_STARTUP_BUDGET_MS}ms)"
+    print -- "  samples (ms, 1st = warm-up, discarded): ${samples[*]}"
+    print -- "  median: ${median}ms  budget: ${budget}ms"
 
-    if (( median > ZSH_STARTUP_BUDGET_MS )); then
-        print -u2 -- "FAIL: startup median ${median}ms exceeds budget ${ZSH_STARTUP_BUDGET_MS}ms"
+    if (( median > budget )); then
+        _print_fail "startup median ${median}ms exceeds budget ${budget}ms"
         return 1
     fi
-
-    print -- "test-startup-budget: ok"
     return 0
 }
 
-_test_startup_budget
-_startup_rc=$?
-unfunction _test_startup_budget 2>/dev/null
-# When executed directly (not sourced by run-tests.zsh), propagate the rc.
-if [[ "${ZSH_EVAL_CONTEXT:-toplevel}" != *file* ]]; then
-    exit $_startup_rc
-fi
-# When sourced, only abort if the test failed — matches the style of
-# tests/test-zshrc-startup.zsh.
-if (( _startup_rc != 0 )); then
-    exit $_startup_rc
-fi
-unset _startup_rc
+register_test "startup_budget_under_cap" test_startup_budget_under_cap

--- a/tests/test-startup-budget.zsh
+++ b/tests/test-startup-budget.zsh
@@ -1,71 +1,85 @@
 #!/usr/bin/env zsh
 # Startup-time budget test.
 #
-# Runs `zsh -i -c exit` N times, computes the median wall-clock time,
-# and fails if it exceeds ZSH_STARTUP_BUDGET_MS. Uses deterministic env:
+# Runs `zsh -i -c exit` several times, computes the median wall-clock time
+# (excluding a warm-up sample), and fails if it exceeds ZSH_STARTUP_BUDGET_MS.
+# Uses deterministic env:
 #   ZSH_FORCE_FULL_INIT=1         — skip non-TTY fast path
 #   ZSH_STATUS_BANNER_MODE=off    — skip heavy status banner
 #   ZSH_AUTO_RECOVER_MODE=off     — skip service auto-recovery
 #
-# Budget can be overridden for local debugging:
+# Overrides:
 #   ZSH_STARTUP_BUDGET_MS=1500 zsh tests/test-startup-budget.zsh
-#
-# CI skips the test entirely if SKIP_STARTUP_BUDGET=1 (escape hatch for
-# known-slow transient CI environments).
+#   SKIP_STARTUP_BUDGET=1 (skips entirely — escape hatch for flaky CI)
 
-set -euo pipefail
+# The test runner sources this file; everything lives inside a function so
+# that `local` is legal and `return` doesn't abort the whole test suite.
+_test_startup_budget() {
+    emulate -L zsh
+    setopt errexit nounset pipefail
 
-ROOT_DIR="${0:A:h:h}"
+    if [[ "${SKIP_STARTUP_BUDGET:-0}" == "1" ]]; then
+        print -- "test-startup-budget: skipped (SKIP_STARTUP_BUDGET=1)"
+        return 0
+    fi
 
-fail() {
-    print -u2 -- "FAIL: $1"
-    exit 1
+    # Budget chosen to catch real regressions without being flaky. Local
+    # measurement on a warm shell runs ~500ms; cold-cache first samples can
+    # hit >1s. The first run is discarded as warm-up; median is taken over
+    # the remaining samples.
+    : "${ZSH_STARTUP_BUDGET_MS:=2500}"
+    : "${ZSH_STARTUP_RUNS:=6}"  # 1 warm-up + 5 measured
+
+    zmodload zsh/datetime 2>/dev/null || {
+        print -u2 -- "FAIL: zsh/datetime module unavailable"
+        return 1
+    }
+
+    local -a samples
+    local i t0 t1 ms
+    for (( i = 1; i <= ZSH_STARTUP_RUNS; i++ )); do
+        t0="$EPOCHREALTIME"
+        ZSH_FORCE_FULL_INIT=1 \
+            ZSH_STATUS_BANNER_MODE=off \
+            ZSH_AUTO_RECOVER_MODE=off \
+            zsh -i -c exit >/dev/null 2>&1
+        t1="$EPOCHREALTIME"
+        ms=$(( (t1 - t0) * 1000 ))
+        ms=${ms%.*}
+        samples+=("$ms")
+    done
+
+    # Discard the first sample as warm-up; take the median of the rest.
+    local -a measured sorted
+    measured=("${(@)samples[2,-1]}")
+    sorted=(${(on)measured})
+    local n=${#sorted}
+    local mid_idx=$(( (n + 1) / 2 ))
+    local median="${sorted[$mid_idx]}"
+
+    print -- "startup samples (ms): ${samples[*]}   (first = warm-up, discarded)"
+    print -- "sorted (measured):    ${sorted[*]}"
+    print -- "median:               ${median}ms  (budget: ${ZSH_STARTUP_BUDGET_MS}ms)"
+
+    if (( median > ZSH_STARTUP_BUDGET_MS )); then
+        print -u2 -- "FAIL: startup median ${median}ms exceeds budget ${ZSH_STARTUP_BUDGET_MS}ms"
+        return 1
+    fi
+
+    print -- "test-startup-budget: ok"
+    return 0
 }
 
-if [[ "${SKIP_STARTUP_BUDGET:-0}" == "1" ]]; then
-    print -- "test-startup-budget: skipped (SKIP_STARTUP_BUDGET=1)"
-    exit 0
+_test_startup_budget
+_startup_rc=$?
+unfunction _test_startup_budget 2>/dev/null
+# When executed directly (not sourced by run-tests.zsh), propagate the rc.
+if [[ "${ZSH_EVAL_CONTEXT:-toplevel}" != *file* ]]; then
+    exit $_startup_rc
 fi
-
-# Budget chosen to catch real regressions without being flaky. Local
-# measurement on a warm shell runs ~500ms; cold-cache first samples can
-# hit >1s. The first run is discarded as warm-up; median is taken over
-# the remaining samples.
-: "${ZSH_STARTUP_BUDGET_MS:=2500}"
-: "${ZSH_STARTUP_RUNS:=6}"  # 1 warm-up + 5 measured
-
-# High-resolution wall-clock via $EPOCHREALTIME (seconds.microseconds).
-zmodload zsh/datetime 2>/dev/null || fail "zsh/datetime module unavailable"
-
-typeset -a samples
-for (( i = 1; i <= ZSH_STARTUP_RUNS; i++ )); do
-    local t0="$EPOCHREALTIME"
-    ZSH_FORCE_FULL_INIT=1 \
-        ZSH_STATUS_BANNER_MODE=off \
-        ZSH_AUTO_RECOVER_MODE=off \
-        zsh -i -c exit >/dev/null 2>&1
-    local t1="$EPOCHREALTIME"
-    # Whole-millisecond wall-clock delta (integer ms).
-    local ms=$(( (t1 - t0) * 1000 ))
-    ms=${ms%.*}
-    samples+=("$ms")
-done
-
-# Discard the first sample as warm-up; take the median of the rest.
-typeset -a measured
-measured=("${(@)samples[2,-1]}")
-typeset -a sorted
-sorted=(${(on)measured})
-local n=${#sorted}
-local mid_idx=$(( (n + 1) / 2 ))
-local median="${sorted[$mid_idx]}"
-
-print -- "startup samples (ms): ${samples[*]}   (first = warm-up, discarded)"
-print -- "sorted (measured):    ${sorted[*]}"
-print -- "median:               ${median}ms  (budget: ${ZSH_STARTUP_BUDGET_MS}ms)"
-
-if (( median > ZSH_STARTUP_BUDGET_MS )); then
-    fail "startup median ${median}ms exceeds budget ${ZSH_STARTUP_BUDGET_MS}ms"
+# When sourced, only abort if the test failed — matches the style of
+# tests/test-zshrc-startup.zsh.
+if (( _startup_rc != 0 )); then
+    exit $_startup_rc
 fi
-
-print -- "test-startup-budget: ok"
+unset _startup_rc


### PR DESCRIPTION
## Summary
- New test \`tests/test-startup-budget.zsh\` fails CI if median interactive-shell startup exceeds 2500ms.
- Uses \`\$EPOCHREALTIME\` (zsh/datetime) for microsecond wall-clock.
- 6 samples with first discarded as warm-up, median of the remaining 5 compared against budget.
- Budget + sample count tunable via env vars; can be fully skipped with \`SKIP_STARTUP_BUDGET=1\`.

## Calibration
- Local warm-shell median: ~580ms.
- Budget: 2500ms — loose enough to absorb CI jitter, tight enough to catch "Stage 5 before CNF removal" levels of regression.
- First PR is expected to establish the budget; tighten later if CI measurements are consistent.

## Test plan
- [x] Passes locally
- [x] Fails synthetically when budget is lowered below observed median (manually verified)
- [ ] CI green

Part of #96, closes #102.