### PR TITLE
fix(test): startup-budget must load the repo's zshrc on CI

### DIFF
--- a/tests/test-startup-budget.zsh
+++ b/tests/test-startup-budget.zsh
@@ -31,19 +31,32 @@ test_startup_budget_under_cap() {
         return 1
     }
 
+    # Prepare a ZDOTDIR that points at the repo's zshrc. Without this, a
+    # subprocess `zsh -i` uses $HOME/.zshrc which is missing on CI runners,
+    # and measurement becomes ~7ms of nothing.
+    local zdot
+    zdot="$(mktemp -d)" || {
+        _print_fail "mktemp failed"
+        return 1
+    }
+    ln -sf "$ROOT_DIR/zshrc" "$zdot/.zshrc"
+
     local -a samples
     local i t0 t1 ms
     for (( i = 1; i <= runs; i++ )); do
         t0="$EPOCHREALTIME"
-        ZSH_FORCE_FULL_INIT=1 \
+        ZDOTDIR="$zdot" \
+            ZSH_FORCE_FULL_INIT=1 \
             ZSH_STATUS_BANNER_MODE=off \
             ZSH_AUTO_RECOVER_MODE=off \
+            ZSH_STARTUP_MODE=immediate \
             zsh -i -c exit >/dev/null 2>&1
         t1="$EPOCHREALTIME"
         ms=$(( (t1 - t0) * 1000 ))
         ms=${ms%.*}
         samples+=("$ms")
     done
+    rm -rf "$zdot"
 
     # Discard the first sample as warm-up; median over the rest.
     local -a measured sorted


### PR DESCRIPTION
## Problem
The just-merged startup-budget test ran \`zsh -i -c exit\` against the CI runner's \$HOME/.zshrc, which doesn't exist on a bare checkout. Subprocess start-exit took ~7ms and the test passed trivially — protecting nothing.

## Fix
Stage a ZDOTDIR in a tmp dir with \`.zshrc\` symlinked to the repo's \`zshrc\`, pass it through env to the subprocess. Also pin \`ZSH_STARTUP_MODE=immediate\` so the staggered IDE path doesn't skew results.

Local re-measurement: median 424ms (vs 217ms in the broken version) — confirms we're now exercising the real config.

## Test plan
- [x] Local run shows median ~420ms, not 7ms
- [ ] CI shows a similarly realistic number
- [ ] CI green

Follow-up to #104, part of #96.