### PR TITLE
ci: add shellcheck gate for bash scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,3 +25,8 @@ jobs:
           ZEPPELIN_HOME: /tmp/stub-zeppelin
           ZSH_TEST_MODE: "1"
         run: zsh run-tests.zsh --verbose
+
+      - name: Shellcheck (bash scripts only — zsh is not supported by shellcheck)
+        run: |
+          brew install --quiet shellcheck
+          shellcheck -S error install.sh setup-software.sh bash-bridge.sh


### PR DESCRIPTION
## Summary
- Adds a shellcheck step to CI at \`-S error\` severity.
- Scope: \`install.sh\`, \`setup-software.sh\`, \`bash-bridge.sh\` only. Shellcheck refuses zsh with SC1071, so \`zshrc\` and \`modules/*.zsh\` are not covered here.

## Current baseline
0 errors on the three scripts today. 4 info-level notes are allowed through (read-without-r, sourced-file-not-followed for SDKMAN init).

## Test plan
- [x] Local \`shellcheck -S error install.sh setup-software.sh bash-bridge.sh\` clean
- [ ] CI green

Part of #96, closes #98.