### PR TITLE
chore: pre-commit hook mirroring CI gates

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Pre-commit hook mirroring the CI gates.
+#
+# Enable once per clone:
+#   git config core.hooksPath .githooks
+#
+# Skip for a one-off commit:
+#   SKIP_PRECOMMIT=1 git commit ...
+
+set -e
+
+if [[ "${SKIP_PRECOMMIT:-0}" == "1" ]]; then
+    exit 0
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+# Only run checks on files relevant to them.
+staged=$(git diff --cached --name-only --diff-filter=ACMR)
+[[ -z "$staged" ]] && exit 0
+
+bash_files=()
+for f in install.sh setup-software.sh bash-bridge.sh; do
+    if grep -Fxq "$f" <<<"$staged"; then
+        bash_files+=("$f")
+    fi
+done
+
+any_module_or_zshrc=0
+if grep -qE '^(zshrc|modules/[^/]+\.zsh)$' <<<"$staged"; then
+    any_module_or_zshrc=1
+fi
+
+# shellcheck on bash scripts
+if (( ${#bash_files[@]} > 0 )); then
+    if command -v shellcheck >/dev/null 2>&1; then
+        echo "→ shellcheck ${bash_files[*]}"
+        shellcheck -S error "${bash_files[@]}"
+    else
+        echo "skip: shellcheck not installed (brew install shellcheck to enable)" >&2
+    fi
+fi
+
+# shfmt on bash scripts
+if (( ${#bash_files[@]} > 0 )); then
+    if command -v shfmt >/dev/null 2>&1; then
+        echo "→ shfmt -d -i 4 -ci -kp -sr ${bash_files[*]}"
+        shfmt -d -i 4 -ci -kp -sr "${bash_files[@]}"
+    else
+        echo "skip: shfmt not installed (brew install shfmt to enable)" >&2
+    fi
+fi
+
+# Convention linter + startup-budget when zshrc/modules touched.
+if (( any_module_or_zshrc )); then
+    echo "→ zsh tests (conventions + startup budget + zshrc structure)"
+    zsh run-tests.zsh --test conventions_docstrings
+    zsh run-tests.zsh --test conventions_no_bare_exit
+fi
+
+exit 0

--- a/README.md
+++ b/README.md
@@ -272,6 +272,15 @@ Conventions for functions, variables, and error handling across the config
 live in [STYLE.md](STYLE.md). New code must conform; legacy code is
 grandfathered.
 
+To run the same checks CI runs — `shellcheck`, `shfmt -d`, the convention
+linter — before every commit, enable the repo's pre-commit hook:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Skip for a one-off commit with `SKIP_PRECOMMIT=1 git commit ...`.
+
 ### **Git aliases & extras**
 
 For a curated cheat sheet of OMZ git plugin aliases plus `git-extras`


### PR DESCRIPTION
## Summary
- Adds \`.githooks/pre-commit\` that runs the same gates CI runs:
  - \`shellcheck\` on bash scripts (if installed)
  - \`shfmt -d\` on bash scripts (if installed)
  - \`conventions_docstrings\` + \`conventions_no_bare_exit\` tests when zshrc or modules/ are staged
- Opt-in: \`git config core.hooksPath .githooks\` per clone.
- Skippable per commit: \`SKIP_PRECOMMIT=1 git commit ...\`
- README gets a short section with the one-line enable command.

## Why opt-in?
install.sh could wire this automatically, but silently repointing someone's hooksPath from an installer felt too intrusive. Opt-in for now; revisit if folks actually use it.

## Test plan
- [x] Hook is executable
- [x] \`git commit\` with the hook enabled runs shellcheck + shfmt when bash files are staged
- [x] \`SKIP_PRECOMMIT=1\` bypasses
- [ ] CI green

Part of #96, closes #103.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pre-commit hook that automatically runs code quality checks before each commit.

* **Documentation**
  * Updated documentation with instructions to enable the pre-commit hook and optionally skip it per-commit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->