### PR TITLE
fix(#90): deflake backup test — global pipefail + SIGPIPE

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -158,11 +158,20 @@ and call it.
 ## Shell flags
 
 - Don't set `set -e` / `set -u` / `set -o pipefail` at the top of
-  modules or tests. They propagate to the sourcing shell and create
-  action-at-a-distance bugs.
+  modules, tests, or `run-tests.zsh`. They propagate to the sourcing
+  shell and create action-at-a-distance bugs.
 - If you need strict mode in a scope, use `emulate -L zsh` + `setopt`
   **inside a function** — `emulate -L` scopes the options to the
   function.
+- **Pipefail gotcha (#90):** `cmd | grep -q "..."` is fragile under
+  `pipefail`. `grep -q` exits on first match; the upstream producer
+  receives SIGPIPE and exits 141; pipefail surfaces the 141 as the
+  pipe's status, so a successful match can fail flakily. Two fixes:
+  1. Don't enable pipefail at runner/test-file scope.
+  2. Capture the producer output first, then grep the variable:
+     `out="$(cmd)"; echo "$out" | grep -q "..."`. No live pipe to the
+     short-circuiting consumer.
+  `test_conventions_runner_no_global_pipefail` guards run-tests.zsh.
 
 ---
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -2,6 +2,33 @@
 
 ## Common Issues and Solutions
 
+### Test suite flakes with unexplained SIGPIPE / exit 141
+
+Symptom: `tests/test-*.zsh` assertions of the form
+`cmd | grep -q "..."` flake — sometimes pass, sometimes fail, with no
+code change. The failing run returns exit 141.
+
+Cause: `pipefail` is enabled globally somewhere. `grep -q` exits on
+first match; upstream producer gets SIGPIPE; `pipefail` surfaces the
+141 as the pipe's overall status, failing the assertion.
+
+Fix: ensure `run-tests.zsh` does **not** enable `pipefail` globally
+(test `conventions_runner_no_global_pipefail` guards this).
+Inside individual tests that genuinely need strict mode, use
+`emulate -L zsh` + `setopt pipefail` inside a function so the option
+is scoped.
+
+Workaround in a single assertion: capture output first, then grep the
+variable, so there's no live pipe:
+
+```zsh
+out="$(cmd)"
+echo "$out" | grep -q "..."
+```
+
+See [STYLE.md](STYLE.md) §Shell flags and GitHub issue #90 for the
+full investigation.
+
 ### Python/Pyenv Not Working - "command not found: pip/python"
 
 **Symptoms:**

--- a/run-tests.zsh
+++ b/run-tests.zsh
@@ -1,5 +1,10 @@
 #!/usr/bin/env zsh
-set -euo pipefail
+# `pipefail` is deliberately NOT set globally: test assertions frequently
+# look like `cmd | grep -q "something"`, and `grep -q` exits as soon as
+# it finds a match. Under pipefail the upstream producer may then be
+# killed by SIGPIPE, turning a successful assertion into a flake. Tests
+# that need strict mode should opt in scoped inside `emulate -L`.
+set -eu
 
 ROOT_DIR="$(cd "$(dirname "${0:A}")" && pwd)"
 TESTS_DIR="$ROOT_DIR/tests"

--- a/tests/test-backup.zsh
+++ b/tests/test-backup.zsh
@@ -74,7 +74,12 @@ test_backup_merge_main_merges_and_returns_branch() {
     assert_contains "$out" "Merged and pushed: feature/merge -> main" "should merge feature branch to main"
     current="$(git -C "$work" branch --show-current)"
     assert_equal "feature/merge" "$current" "should return to original branch after merge"
-    assert_command_success "git --git-dir '$root/origin.git' log --oneline main | grep -q \"feat: merge target\"" "origin main should include merged commit"
+    # Capture the log before greping so the pipe can't be killed by SIGPIPE
+    # under `pipefail` (grep -q short-circuits on match, producer gets
+    # SIGPIPE, and with pipefail the pipe as a whole reports failure).
+    local merge_log
+    merge_log="$(git --git-dir "$root/origin.git" log --oneline main 2>&1)"
+    assert_contains "$merge_log" "feat: merge target" "origin main should include merged commit"
 
     ZSHRC_CONFIG_DIR="$old_dir"
     rm -rf "$root"
@@ -94,7 +99,10 @@ test_pushmain_commits_pushes_and_merges() {
     assert_contains "$out" "Backup complete" "pushmain should run backup"
     assert_contains "$out" "Merged and pushed: feature/pushmain -> main" "pushmain should merge to main"
     assert_command_success "git --git-dir '$root/origin.git' show-ref --verify --quiet refs/heads/feature/pushmain" "origin should have pushed feature branch"
-    assert_command_success "git --git-dir '$root/origin.git' log --oneline main | grep -q \"pushmain integration test\"" "origin main should include pushmain commit"
+    # Capture then grep — see note in test_backup_merge_main_merges_and_returns_branch above.
+    local pushmain_log
+    pushmain_log="$(git --git-dir "$root/origin.git" log --oneline main 2>&1)"
+    assert_contains "$pushmain_log" "pushmain integration test" "origin main should include pushmain commit"
     current="$(git -C "$work" branch --show-current)"
     assert_equal "feature/pushmain" "$current" "pushmain should return to original branch"
 

--- a/tests/test-conventions.zsh
+++ b/tests/test-conventions.zsh
@@ -107,5 +107,20 @@ test_conventions_no_bare_exit() {
     return 0
 }
 
+test_conventions_runner_no_global_pipefail() {
+    # `set -o pipefail` at global scope in run-tests.zsh silently broke
+    # assertions of the form `cmd | grep -q "..."`: grep -q exits on match,
+    # upstream producer gets SIGPIPE, and pipefail surfaces the 141 as the
+    # pipeline's status, failing flakily. Scoped inside `emulate -L` is fine;
+    # unscoped at run-tests.zsh top level is not. See #90 for the history.
+    # Match only statement lines, not comment lines, that enable pipefail.
+    if grep -qE '^[[:space:]]*(set[[:space:]]+[^#]*pipefail|setopt[[:space:]]+[^#]*pipefail)' "$ROOT_DIR/run-tests.zsh"; then
+        _print_fail "run-tests.zsh must not enable pipefail globally (#90)"
+        return 1
+    fi
+    return 0
+}
+
 register_test "conventions_docstrings" test_conventions_docstrings
 register_test "conventions_no_bare_exit" test_conventions_no_bare_exit
+register_test "conventions_runner_no_global_pipefail" test_conventions_runner_no_global_pipefail

--- a/tests/test-zshrc-startup.zsh
+++ b/tests/test-zshrc-startup.zsh
@@ -1,112 +1,127 @@
 #!/usr/bin/env zsh
+# Structural invariants of zshrc: helper presence, OMZ knobs/plugins,
+# archived-module guard, and XDG-cache compinit behavior.
+#
+# The body runs inside a function so `set -euo pipefail` and scratch
+# locals are scoped. A top-level `set -euo pipefail` would LEAK into
+# the test runner's shell when this file is sourced, causing downstream
+# tests that pipe to short-circuiting tools (e.g. `grep -q`) to flake
+# under SIGPIPE. See #90 and the flake investigation in the commit
+# that introduced this scoping.
 
-set -euo pipefail
+# Capture the test file's location BEFORE entering the function —
+# inside a function, $0 refers to the function name, not the file.
+_ZSHRC_TEST_ROOT="${0:A:h:h}"
 
-ROOT_DIR="${0:A:h:h}"
-ZSHRC_FILE="$ROOT_DIR/zshrc"
+_test_zshrc_structure() {
+    emulate -L zsh
+    setopt errexit nounset pipefail
 
-fail() {
-  print -u2 -- "FAIL: $1"
-  exit 1
+    local ROOT_DIR="$_ZSHRC_TEST_ROOT"
+    local ZSHRC_FILE="$ROOT_DIR/zshrc"
+
+    local _p _m _first_plugin _last_plugin
+    local _knob_line _omz_line
+    local _cache_tmp _home_tmp _block
+    local -a _archived_modules _dumps _stragglers
+
+    fail() {
+        print -u2 -- "FAIL: $1"
+        return 1
+    }
+
+    grep -q '_zsh_is_warp_terminal()' "$ZSHRC_FILE" || fail "missing Warp detection helper" || return 1
+    grep -q '_zsh_show_full_startup_banner()' "$ZSHRC_FILE" || fail "missing startup banner mode helper" || return 1
+    grep -q '_zsh_should_auto_recover_services()' "$ZSHRC_FILE" || fail "missing auto recover mode helper" || return 1
+    grep -q 'ZSH_STATUS_BANNER_MODE:=auto' "$ZSHRC_FILE" || fail "missing banner mode default" || return 1
+    grep -q 'ZSH_AUTO_RECOVER_MODE:=auto' "$ZSHRC_FILE" || fail "missing auto-recover mode default" || return 1
+    grep -q 'if _zsh_should_auto_recover_services; then' "$ZSHRC_FILE" || fail "missing guarded auto-recover call" || return 1
+    grep -q 'if _zsh_show_full_startup_banner; then' "$ZSHRC_FILE" || fail "missing guarded banner call" || return 1
+
+    # OMZ overhead knobs — all must be set before sourcing oh-my-zsh.sh.
+    grep -q "zstyle ':omz:update' mode disabled" "$ZSHRC_FILE" || fail "missing OMZ auto-update disable" || return 1
+    grep -q 'ZSH_DISABLE_COMPFIX=true' "$ZSHRC_FILE" || fail "missing ZSH_DISABLE_COMPFIX=true" || return 1
+    grep -q 'DISABLE_MAGIC_FUNCTIONS=true' "$ZSHRC_FILE" || fail "missing DISABLE_MAGIC_FUNCTIONS=true" || return 1
+    grep -q 'DISABLE_AUTO_TITLE=true' "$ZSHRC_FILE" || fail "missing DISABLE_AUTO_TITLE=true" || return 1
+    _knob_line=$(grep -n "zstyle ':omz:update' mode disabled" "$ZSHRC_FILE" | head -1 | cut -d: -f1)
+    _omz_line=$(grep -n 'source "\$ZSH/oh-my-zsh.sh"' "$ZSHRC_FILE" | head -1 | cut -d: -f1)
+    [[ -n "$_knob_line" && -n "$_omz_line" && "$_knob_line" -lt "$_omz_line" ]] \
+        || { fail "OMZ knobs must appear before the oh-my-zsh.sh source line"; return 1; }
+
+    for _p in git gitfast gh fzf sudo copybuffer copypath copyfile history-substring-search aliases brew; do
+        grep -qE "^\s+${_p}\b" "$ZSHRC_FILE" \
+            || { fail "expected OMZ plugin '${_p}' to be enabled"; return 1; }
+    done
+    if grep -qE "^\s+command-not-found\b" "$ZSHRC_FILE"; then
+        fail "command-not-found must not be in plugins=(...) — too slow at startup"; return 1
+    fi
+
+    for _p in zsh-defer zsh-autosuggestions zsh-syntax-highlighting zsh-completions; do
+        grep -qE "^\s+${_p}\b" "$ZSHRC_FILE" \
+            || { fail "expected third-party plugin '${_p}' to be enabled"; return 1; }
+    done
+    _first_plugin=$(awk '/^plugins=\(/{flag=1; next} flag && /^[ \t]+[a-z]/{print $1; exit}' "$ZSHRC_FILE")
+    [[ "$_first_plugin" == "zsh-defer" ]] \
+        || { fail "zsh-defer must be the first plugin (got: '${_first_plugin}')"; return 1; }
+    _last_plugin=$(awk '/^plugins=\(/{flag=1; next} /^\)/{flag=0} flag && /^[ \t]+[a-z]/{p=$1} END{print p}' "$ZSHRC_FILE")
+    [[ "$_last_plugin" == "zsh-syntax-highlighting" ]] \
+        || { fail "zsh-syntax-highlighting must be the last plugin (got: '${_last_plugin}')"; return 1; }
+
+    grep -q "zsh-defer source .*command-not-found" "$ZSHRC_FILE" \
+        || { fail "command-not-found should be deferred via zsh-defer"; return 1; }
+
+    grep -qE "^\s+git-extras\b" "$ZSHRC_FILE" \
+        || { fail "expected OMZ plugin 'git-extras' to be enabled"; return 1; }
+    [[ -f "$ROOT_DIR/docs/git-aliases.md" ]] \
+        || { fail "docs/git-aliases.md cheat sheet missing"; return 1; }
+
+    grep -q "bindkey '\^\[\[A' history-substring-search-up" "$ZSHRC_FILE" \
+        || { fail "history-substring-search up-arrow binding missing"; return 1; }
+    grep -q "bindkey '\^\[\[B' history-substring-search-down" "$ZSHRC_FILE" \
+        || { fail "history-substring-search down-arrow binding missing"; return 1; }
+
+    # Archived modules must not be loaded from zshrc.
+    _archived_modules=("$ROOT_DIR"/modules/archived/*.zsh(N:t:r))
+    for _m in $_archived_modules; do
+        [[ "$_m" == "README" ]] && continue
+        if grep -qE "^\s*load_module\s+${_m}\b" "$ZSHRC_FILE"; then
+            fail "archived module '${_m}' is still loaded from zshrc"; return 1
+        fi
+    done
+
+    # Completion cache must live under $XDG_CACHE_HOME/zsh.
+    grep -q 'XDG_CACHE_HOME:=\$HOME/.cache' "$ZSHRC_FILE" || { fail "missing XDG_CACHE_HOME default"; return 1; }
+    grep -q '_zcompdump="\$XDG_CACHE_HOME/zsh/zcompdump-' "$ZSHRC_FILE" \
+        || { fail "_zcompdump path should be rooted in \$XDG_CACHE_HOME/zsh/"; return 1; }
+    grep -q 'compinit -d "\$_zcompdump"' "$ZSHRC_FILE" \
+        || { fail "compinit must target \$_zcompdump with -d (rebuild path)"; return 1; }
+    grep -q 'compinit -C -d "\$_zcompdump"' "$ZSHRC_FILE" \
+        || { fail "compinit fast path must target \$_zcompdump with -C -d"; return 1; }
+
+    # Behavioral check: execute the compinit block with scratch HOME/XDG.
+    _cache_tmp="$(mktemp -d)" || { fail "mktemp failed"; return 1; }
+    _home_tmp="$(mktemp -d)" || { fail "mktemp failed"; return 1; }
+    _block="$(awk '/^# Initialize completion system/,/^unset _zcompdump/' "$ZSHRC_FILE")"
+    [[ -n "$_block" ]] || { fail "could not extract compinit block from zshrc"; rm -rf "$_cache_tmp" "$_home_tmp"; return 1; }
+    HOME="$_home_tmp" XDG_CACHE_HOME="$_cache_tmp" \
+        zsh -c "$_block" >/dev/null 2>&1 \
+        || { fail "compinit block errored under scratch HOME/XDG"; rm -rf "$_cache_tmp" "$_home_tmp"; return 1; }
+    _dumps=("$_cache_tmp"/zsh/zcompdump-*(N))
+    _stragglers=("$_home_tmp"/.zcompdump*(N))
+    rm -rf "$_cache_tmp" "$_home_tmp"
+    (( ${#_dumps} > 0 )) \
+        || { fail "expected zcompdump under \$XDG_CACHE_HOME/zsh/, found none"; return 1; }
+    (( ${#_stragglers} == 0 )) \
+        || { fail "compinit block leaked .zcompdump* into \$HOME"; return 1; }
+
+    print -- "test-zshrc-startup: ok"
+    return 0
 }
 
-grep -q '_zsh_is_warp_terminal()' "$ZSHRC_FILE" || fail "missing Warp detection helper"
-grep -q '_zsh_show_full_startup_banner()' "$ZSHRC_FILE" || fail "missing startup banner mode helper"
-grep -q '_zsh_should_auto_recover_services()' "$ZSHRC_FILE" || fail "missing auto recover mode helper"
-grep -q 'ZSH_STATUS_BANNER_MODE:=auto' "$ZSHRC_FILE" || fail "missing banner mode default"
-grep -q 'ZSH_AUTO_RECOVER_MODE:=auto' "$ZSHRC_FILE" || fail "missing auto-recover mode default"
-grep -q 'if _zsh_should_auto_recover_services; then' "$ZSHRC_FILE" || fail "missing guarded auto-recover call"
-grep -q 'if _zsh_show_full_startup_banner; then' "$ZSHRC_FILE" || fail "missing guarded banner call"
-
-# OMZ overhead knobs — all must be set before sourcing oh-my-zsh.sh.
-grep -q "zstyle ':omz:update' mode disabled" "$ZSHRC_FILE" \
-  || fail "missing OMZ auto-update disable"
-grep -q 'ZSH_DISABLE_COMPFIX=true' "$ZSHRC_FILE" \
-  || fail "missing ZSH_DISABLE_COMPFIX=true"
-grep -q 'DISABLE_MAGIC_FUNCTIONS=true' "$ZSHRC_FILE" \
-  || fail "missing DISABLE_MAGIC_FUNCTIONS=true"
-grep -q 'DISABLE_AUTO_TITLE=true' "$ZSHRC_FILE" \
-  || fail "missing DISABLE_AUTO_TITLE=true"
-# Order matters: knobs must appear before the oh-my-zsh.sh source line.
-_knob_line=$(grep -n "zstyle ':omz:update' mode disabled" "$ZSHRC_FILE" | head -1 | cut -d: -f1)
-_omz_line=$(grep -n 'source "\$ZSH/oh-my-zsh.sh"' "$ZSHRC_FILE" | head -1 | cut -d: -f1)
-[[ -n "$_knob_line" && -n "$_omz_line" && "$_knob_line" -lt "$_omz_line" ]] \
-  || fail "OMZ knobs must appear before the oh-my-zsh.sh source line"
-
-# Low-cost OMZ plugin enrichment. Each plugin should appear in plugins=(...)
-# and none of the deliberately-excluded heavy ones should leak in.
-for _p in git gitfast gh fzf sudo copybuffer copypath copyfile history-substring-search aliases brew; do
-    grep -qE "^\s+${_p}\b" "$ZSHRC_FILE" \
-        || fail "expected OMZ plugin '${_p}' to be enabled"
-done
-# command-not-found is intentionally excluded (brew init is slow).
-grep -qE "^\s+command-not-found\b" "$ZSHRC_FILE" \
-    && fail "command-not-found must not be in plugins=(...) — too slow at startup"
-
-# Third-party plugins + deferred loading.
-for _p in zsh-defer zsh-autosuggestions zsh-syntax-highlighting zsh-completions; do
-    grep -qE "^\s+${_p}\b" "$ZSHRC_FILE" \
-        || fail "expected third-party plugin '${_p}' to be enabled"
-done
-# zsh-defer must be the first plugin so later plugins can use it.
-_first_plugin=$(awk '/^plugins=\(/{flag=1; next} flag && /^[ \t]+[a-z]/{print $1; exit}' "$ZSHRC_FILE")
-[[ "$_first_plugin" == "zsh-defer" ]] \
-    || fail "zsh-defer must be the first plugin (got: '${_first_plugin}')"
-# zsh-syntax-highlighting must be the last plugin.
-_last_plugin=$(awk '/^plugins=\(/{flag=1; next} /^\)/{flag=0} flag && /^[ \t]+[a-z]/{p=$1} END{print p}' "$ZSHRC_FILE")
-[[ "$_last_plugin" == "zsh-syntax-highlighting" ]] \
-    || fail "zsh-syntax-highlighting must be the last plugin (got: '${_last_plugin}')"
-
-# command-not-found must be loaded via zsh-defer (not inline).
-grep -q "zsh-defer source .*command-not-found" "$ZSHRC_FILE" \
-    || fail "command-not-found should be deferred via zsh-defer"
-
-# git-extras plugin enabled.
-grep -qE "^\s+git-extras\b" "$ZSHRC_FILE" \
-    || fail "expected OMZ plugin 'git-extras' to be enabled"
-# Cheat sheet shipped.
-[[ -f "$ROOT_DIR/docs/git-aliases.md" ]] \
-    || fail "docs/git-aliases.md cheat sheet missing"
-
-# history-substring-search requires arrow-key bindings after OMZ loads.
-grep -q "bindkey '\^\[\[A' history-substring-search-up" "$ZSHRC_FILE" \
-    || fail "history-substring-search up-arrow binding missing"
-grep -q "bindkey '\^\[\[B' history-substring-search-down" "$ZSHRC_FILE" \
-    || fail "history-substring-search down-arrow binding missing"
-
-# Archived modules must not be loaded from zshrc.
-_archived_modules=("$ROOT_DIR"/modules/archived/*.zsh(N:t:r))
-for _m in $_archived_modules; do
-    [[ "$_m" == "README" ]] && continue
-    if grep -qE "^\s*load_module\s+${_m}\b" "$ZSHRC_FILE"; then
-        fail "archived module '${_m}' is still loaded from zshrc"
-    fi
-done
-
-# Completion cache must live under $XDG_CACHE_HOME/zsh, not the repo root.
-grep -q 'XDG_CACHE_HOME:=\$HOME/.cache' "$ZSHRC_FILE" || fail "missing XDG_CACHE_HOME default"
-grep -q '_zcompdump="\$XDG_CACHE_HOME/zsh/zcompdump-' "$ZSHRC_FILE" \
-  || fail "_zcompdump path should be rooted in \$XDG_CACHE_HOME/zsh/"
-grep -q 'compinit -d "\$_zcompdump"' "$ZSHRC_FILE" \
-  || fail "compinit must target \$_zcompdump with -d (rebuild path)"
-grep -q 'compinit -C -d "\$_zcompdump"' "$ZSHRC_FILE" \
-  || fail "compinit fast path must target \$_zcompdump with -C -d"
-
-# Behavioral check: executing just the compinit block writes under $XDG_CACHE_HOME/zsh,
-# not into $HOME. Extract lines between the compinit comment and the `unset _zcompdump`
-# marker, then run them in a subshell with scratch HOME/XDG.
-_cache_tmp="$(mktemp -d 2>/dev/null)" || fail "mktemp failed"
-_home_tmp="$(mktemp -d 2>/dev/null)" || fail "mktemp failed"
-trap 'rm -rf "$_cache_tmp" "$_home_tmp"' EXIT
-_block="$(awk '/^# Initialize completion system/,/^unset _zcompdump/' "$ZSHRC_FILE")"
-[[ -n "$_block" ]] || fail "could not extract compinit block from zshrc"
-HOME="$_home_tmp" XDG_CACHE_HOME="$_cache_tmp" \
-  zsh -c "$_block" >/dev/null 2>&1 || fail "compinit block errored under scratch HOME/XDG"
-_dumps=("$_cache_tmp"/zsh/zcompdump-*(N))
-(( ${#_dumps} > 0 )) \
-  || fail "expected zcompdump under \$XDG_CACHE_HOME/zsh/, found none"
-_stragglers=("$_home_tmp"/.zcompdump*(N))
-(( ${#_stragglers} == 0 )) \
-  || fail "compinit block leaked .zcompdump* into \$HOME"
-
-print -- "test-zshrc-startup: ok"
+_test_zshrc_structure
+_zshrc_structure_rc=$?
+unfunction _test_zshrc_structure 2>/dev/null
+if (( _zshrc_structure_rc != 0 )); then
+    exit $_zshrc_structure_rc
+fi
+unset _zshrc_structure_rc _ZSHRC_TEST_ROOT


### PR DESCRIPTION
## Root cause
\`run-tests.zsh\` set \`-o pipefail\` globally. Two backup-test assertions used \`git log | grep -q "..."\`. \`grep -q\` exits on match; \`git\` gets SIGPIPE and exits 141; with pipefail, 141 becomes the pipeline's status; the assertion fails flakily.

Locally reproduced at ~20% flake rate. Deterministic CI escape hatch was rerun-until-pass, which is not a fix.

## Changes
1. **\`run-tests.zsh\`**: drop \`pipefail\`; keep \`-eu\`. Comment explains why.
2. **\`tests/test-zshrc-startup.zsh\`**: wrap body in \`emulate -L\` function so \`setopt pipefail\` is scoped (was leaking at top level).
3. **\`tests/test-backup.zsh\`**: rewrite the two fragile assertions to capture output first, grep the variable — no live pipe, no SIGPIPE.
4. **\`tests/test-conventions.zsh\`**: new regression test \`conventions_runner_no_global_pipefail\` guards run-tests.zsh.
5. **Docs**: STYLE.md §Shell flags gains a "pipefail gotcha" note; TROUBLESHOOTING.md has a top-entry covering symptom + fix.

## Verification
- 50/50 passes locally on the previously-flaky test
- Full suite: 222 tests, 3 pre-existing env failures only
- Regression test correctly flags a synthetic reintroduction of \`set -o pipefail\` in run-tests.zsh

Closes #90.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved test suite flakiness caused by shell pipeline assertions.
  * Improved error handling and isolation in test execution.

* **Tests**
  * Added validation to ensure proper test runner configuration.

* **Documentation**
  * Added troubleshooting guide for intermittent test failures.
  * Updated development guidelines with failure modes and mitigation strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->