### PR TITLE
perf: opt-in data-platform module deferral

### DIFF
--- a/wiki/Startup-Performance.md
+++ b/wiki/Startup-Performance.md
@@ -42,6 +42,16 @@ From a representative `ZSH_PROFILE=1` run on macOS (warm cache):
 | `_secrets_export_kv` | ~120 total (23 calls) | Bounded by secrets.env size. |
 | `fzf_setup_using_base_dir` | ~80 | One-time fzf plugin init. |
 
+## Opt-in deferral
+
+- `ZSH_DEFER_DATA_PLATFORM=1` — defers `spark`, `hadoop`, `livy`, and
+  `zeppelin` module sourcing via `zsh-defer` until after the first
+  prompt renders. Useful if you rarely (or never) use these tools
+  from this shell. Off by default because the startup status banner
+  calls a couple of spark/hadoop helpers during init; enabling the
+  flag makes those banner lines skip until the deferred sourcing
+  completes a moment later.
+
 ## Warp defaults
 
 Interactive startup now takes a lighter path inside Warp by default.

--- a/zshrc
+++ b/zshrc
@@ -333,7 +333,7 @@ else
     export ZSH_IS_IDE_TERMINAL=0
     # Regular terminal - load everything immediately (fast enough)
     echo "🚀 Loading modules..."
-    
+
     load_module utils
     load_module settings
     load_module compat
@@ -351,10 +351,23 @@ else
     load_module dataworld
     load_module databricks
     load_module docker
-    load_module spark
-    load_module hadoop
-    load_module livy
-    load_module zeppelin
+
+    # Heavy data-platform modules. Defer past first prompt when the
+    # user opts in via ZSH_DEFER_DATA_PLATFORM=1. Deferring is not the
+    # default because the startup status banner calls spark_/hadoop_
+    # functions during init; deferring breaks them in that window.
+    if [[ "${ZSH_DEFER_DATA_PLATFORM:-0}" == "1" ]] \
+       && (( ${+functions[zsh-defer]} )); then
+        zsh-defer load_module spark
+        zsh-defer load_module hadoop
+        zsh-defer load_module livy
+        zsh-defer load_module zeppelin
+    else
+        load_module spark
+        load_module hadoop
+        load_module livy
+        load_module zeppelin
+    fi
 fi
 
 # =================================================================


### PR DESCRIPTION
Adds `ZSH_DEFER_DATA_PLATFORM=1` — when set, spark/hadoop/livy/zeppelin load via zsh-defer after first prompt. Off by default because the startup banner calls spark/hadoop helpers during init.

Closes #130. Part of #124.