### PR TITLE
test: unskip pushmain + git_sync_safe backup tests

### DIFF
--- a/tests/test-backup.zsh
+++ b/tests/test-backup.zsh
@@ -86,7 +86,6 @@ test_backup_merge_main_merges_and_returns_branch() {
 }
 
 test_pushmain_commits_pushes_and_merges() {
-    skip_in_ci
     local old_dir="$ZSHRC_CONFIG_DIR"
     local root work out current
     root="$(_make_backup_test_repo)"
@@ -111,7 +110,6 @@ test_pushmain_commits_pushes_and_merges() {
 }
 
 test_git_sync_safe_autostash() {
-    skip_in_ci
     local old_dir="$ZSHRC_CONFIG_DIR"
     local root work clone out
     root="$(_make_backup_test_repo)"


### PR DESCRIPTION
These were gated on `skip_in_ci` from the #90 flake era. That flake is fixed. Verified 20/20 locally.

Closes #133. Part of #125.