### PR TITLE
feat: ZSH_DISABLE_<MODULE>=1 opt-out flags

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -175,6 +175,28 @@ and call it.
 
 ---
 
+## Module feature flags
+
+Any module can be opted out of a shell by exporting
+`ZSH_DISABLE_<NAME>=1` before shell start, where `<NAME>` is the
+uppercase module file stem with hyphens swapped for underscores.
+Honored by `load_module` in `zshrc`.
+
+Examples:
+
+```sh
+# Skip the Spark / Hadoop / Zeppelin trio on a lightweight host:
+export ZSH_DISABLE_SPARK=1
+export ZSH_DISABLE_HADOOP=1
+export ZSH_DISABLE_ZEPPELIN=1
+
+# Debug-only: run a shell without docker helpers:
+ZSH_DISABLE_DOCKER=1 zsh -i
+```
+
+Per-host `vars.<host>.env` files are the conventional place to set
+these for a given machine.
+
 ## Enforcement
 
 - `tests/test-zshrc-startup.zsh` — structural invariants of `zshrc`.

--- a/tests/README.md
+++ b/tests/README.md
@@ -24,6 +24,7 @@ Minimal zsh test framework and test suites for this repo.
 - `test-startup-budget.zsh`
 - `test-conventions.zsh`
 - `test-doctor.zsh`
+- `test-module-flags.zsh`
 - `test-backup.zsh`
 - `test-database.zsh`
 - `test-docker.zsh`

--- a/tests/test-module-flags.zsh
+++ b/tests/test-module-flags.zsh
@@ -1,0 +1,48 @@
+#!/usr/bin/env zsh
+
+ROOT_DIR="$(cd "$(dirname "${0:A}")/.." && pwd)"
+source "$ROOT_DIR/tests/test-framework.zsh"
+
+# Extract the load_module function from zshrc and run it in a subshell
+# so we don't have to source the whole config.
+_extract_load_module() {
+    awk '/^load_module\(\)/,/^\}/' "$ROOT_DIR/zshrc"
+}
+
+test_load_module_honors_disable_flag() {
+    # With ZSH_DISABLE_<NAME>=1, the module should NOT be sourced.
+    local tmp out
+    tmp="$(mktemp -d)"
+    mkdir -p "$tmp/modules"
+    echo 'echo LOADED_FROM_FAKE_MODULE' > "$tmp/modules/fake.zsh"
+    local loader="$(_extract_load_module)"
+    out="$(ZSH_CONFIG_DIR="$tmp" ZSH_DISABLE_FAKE=1 zsh -c "$loader; load_module fake")"
+    rm -rf "$tmp"
+    assert_equal "" "$out" "ZSH_DISABLE_FAKE=1 should skip the module source"
+}
+
+test_load_module_loads_when_flag_unset() {
+    local tmp out
+    tmp="$(mktemp -d)"
+    mkdir -p "$tmp/modules"
+    echo 'echo LOADED_FROM_FAKE_MODULE' > "$tmp/modules/fake.zsh"
+    local loader="$(_extract_load_module)"
+    out="$(ZSH_CONFIG_DIR="$tmp" zsh -c "$loader; load_module fake")"
+    rm -rf "$tmp"
+    assert_equal "LOADED_FROM_FAKE_MODULE" "$out" "load_module should source by default"
+}
+
+test_load_module_flag_maps_hyphen_to_underscore() {
+    local tmp out
+    tmp="$(mktemp -d)"
+    mkdir -p "$tmp/modules"
+    echo 'echo LOADED_HYPHEN' > "$tmp/modules/my-module.zsh"
+    local loader="$(_extract_load_module)"
+    out="$(ZSH_CONFIG_DIR="$tmp" ZSH_DISABLE_MY_MODULE=1 zsh -c "$loader; load_module my-module")"
+    rm -rf "$tmp"
+    assert_equal "" "$out" "hyphens should map to underscores in the flag name"
+}
+
+register_test "load_module_honors_disable_flag" test_load_module_honors_disable_flag
+register_test "load_module_loads_when_flag_unset" test_load_module_loads_when_flag_unset
+register_test "load_module_flag_maps_hyphen_to_underscore" test_load_module_flag_maps_hyphen_to_underscore

--- a/tests/test-module-flags.zsh
+++ b/tests/test-module-flags.zsh
@@ -16,7 +16,7 @@ test_load_module_honors_disable_flag() {
     mkdir -p "$tmp/modules"
     echo 'echo LOADED_FROM_FAKE_MODULE' > "$tmp/modules/fake.zsh"
     local loader="$(_extract_load_module)"
-    out="$(ZSH_CONFIG_DIR="$tmp" ZSH_DISABLE_FAKE=1 zsh -c "$loader; load_module fake")"
+    out="$(ZSH_CONFIG_DIR="$tmp" ZSH_DISABLE_FAKE=1 zsh -fc "$loader; load_module fake")"
     rm -rf "$tmp"
     assert_equal "" "$out" "ZSH_DISABLE_FAKE=1 should skip the module source"
 }
@@ -27,7 +27,7 @@ test_load_module_loads_when_flag_unset() {
     mkdir -p "$tmp/modules"
     echo 'echo LOADED_FROM_FAKE_MODULE' > "$tmp/modules/fake.zsh"
     local loader="$(_extract_load_module)"
-    out="$(ZSH_CONFIG_DIR="$tmp" zsh -c "$loader; load_module fake")"
+    out="$(ZSH_CONFIG_DIR="$tmp" zsh -fc "$loader; load_module fake")"
     rm -rf "$tmp"
     assert_equal "LOADED_FROM_FAKE_MODULE" "$out" "load_module should source by default"
 }
@@ -38,7 +38,7 @@ test_load_module_flag_maps_hyphen_to_underscore() {
     mkdir -p "$tmp/modules"
     echo 'echo LOADED_HYPHEN' > "$tmp/modules/my-module.zsh"
     local loader="$(_extract_load_module)"
-    out="$(ZSH_CONFIG_DIR="$tmp" ZSH_DISABLE_MY_MODULE=1 zsh -c "$loader; load_module my-module")"
+    out="$(ZSH_CONFIG_DIR="$tmp" ZSH_DISABLE_MY_MODULE=1 zsh -fc "$loader; load_module my-module")"
     rm -rf "$tmp"
     assert_equal "" "$out" "hyphens should map to underscores in the flag name"
 }

--- a/zshrc
+++ b/zshrc
@@ -242,9 +242,23 @@ _zsh_startup_use_staggered() {
     esac
 }
 
-# Module loader
+# Module loader.
+#
+# Per-module opt-out flag: set `ZSH_DISABLE_<UPPERNAME>=1` to skip a
+# module's load. Name-to-env-var mapping uppercases the module name
+# and replaces hyphens with underscores. Examples:
+#   ZSH_DISABLE_SPARK=1     # skip modules/spark.zsh
+#   ZSH_DISABLE_ZEPPELIN=1  # skip modules/zeppelin.zsh
+#   ZSH_DISABLE_SECRETS=1   # skip modules/secrets.zsh (advanced)
+#
+# Useful in per-host vars files or on-the-fly for debugging.
 load_module() {
     local module="$1"
+    local flag_name="ZSH_DISABLE_${module:u}"
+    flag_name="${flag_name//-/_}"
+    if [[ "${(P)flag_name:-0}" == "1" ]]; then
+        return 0
+    fi
     if [[ -f "$ZSH_CONFIG_DIR/modules/$module.zsh" ]]; then
         source "$ZSH_CONFIG_DIR/modules/$module.zsh"
     else


### PR DESCRIPTION
Any module gets a `ZSH_DISABLE_<NAME>=1` opt-out. Case-normalizes and hyphen→underscore maps.

Closes #138.