### PR TITLE
feat(env-detect): zsh_env / zsh_env_snapshot registry

### DIFF
--- a/modules/env_detect.zsh
+++ b/modules/env_detect.zsh
@@ -1,0 +1,53 @@
+#!/usr/bin/env zsh
+# =================================================================
+# ENV_DETECT — environment detection registry
+# =================================================================
+# Consolidated inspection helpers. Modules that want to answer "what
+# terminal / mode are we in?" should ask the registry instead of
+# reimplementing the check.
+#
+# The registry does NOT replace the existing zshrc-level helpers
+# (_zsh_is_warp_terminal, detect_ide, _zsh_startup_use_staggered);
+# it wraps them plus a couple of new checks into a single
+# introspectable surface.
+
+# Print a line-per-fact snapshot of the shell's detected environment.
+# Stable key=value format, safe for scripting and for zsh_doctor use.
+zsh_env_snapshot() {
+    emulate -L zsh
+    local is_ide=0 is_warp=0 is_vscode=0 is_cursor=0 is_ci=0 is_staggered=0
+
+    if (( ${+functions[detect_ide]} )) && detect_ide 2>/dev/null; then
+        is_ide=1
+    fi
+    if (( ${+functions[_zsh_is_warp_terminal]} )) && _zsh_is_warp_terminal; then
+        is_warp=1
+    fi
+    [[ "${TERM_PROGRAM:-}" == "vscode" ]] && is_vscode=1
+    [[ "${TERM_PROGRAM:-}" == "Cursor" ]] && is_cursor=1
+    [[ -n "${GITHUB_ACTIONS:-}${CI:-}" ]] && is_ci=1
+    if (( ${+functions[_zsh_startup_use_staggered]} )) && _zsh_startup_use_staggered; then
+        is_staggered=1
+    fi
+
+    printf 'os=%s\n' "$OSTYPE"
+    printf 'shell=%s\n' "zsh $ZSH_VERSION"
+    printf 'term_program=%s\n' "${TERM_PROGRAM:-unknown}"
+    printf 'is_warp=%d\n' "$is_warp"
+    printf 'is_vscode=%d\n' "$is_vscode"
+    printf 'is_cursor=%d\n' "$is_cursor"
+    printf 'is_ide=%d\n' "$is_ide"
+    printf 'is_ci=%d\n' "$is_ci"
+    printf 'is_staggered=%d\n' "$is_staggered"
+    printf 'full_init=%s\n' "${ZSH_FORCE_FULL_INIT:-0}"
+    printf 'test_mode=%s\n' "${ZSH_TEST_MODE:-0}"
+    printf 'profile=%s\n' "${ZSH_PROFILE:-0}"
+}
+
+# Query a single fact by name. Useful in conditionals:
+#   if [[ "$(zsh_env is_warp)" == "1" ]]; then ...
+zsh_env() {
+    local key="${1:-}"
+    [[ -z "$key" ]] && { zsh_env_snapshot; return 0; }
+    zsh_env_snapshot | awk -F= -v k="$key" '$1==k {print $2; found=1} END {exit !found}'
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -25,6 +25,7 @@ Minimal zsh test framework and test suites for this repo.
 - `test-conventions.zsh`
 - `test-doctor.zsh`
 - `test-module-flags.zsh`
+- `test-env-detect.zsh`
 - `test-backup.zsh`
 - `test-database.zsh`
 - `test-docker.zsh`

--- a/tests/test-env-detect.zsh
+++ b/tests/test-env-detect.zsh
@@ -1,0 +1,28 @@
+#!/usr/bin/env zsh
+
+ROOT_DIR="$(cd "$(dirname "${0:A}")/.." && pwd)"
+source "$ROOT_DIR/tests/test-framework.zsh"
+source "$ROOT_DIR/modules/env_detect.zsh"
+
+test_env_snapshot_has_expected_keys() {
+    local out
+    out="$(zsh_env_snapshot)"
+    for k in os shell term_program is_warp is_vscode is_cursor is_ide is_ci is_staggered full_init test_mode profile; do
+        assert_contains "$out" "${k}=" "snapshot should include ${k}="
+    done
+}
+
+test_env_query_returns_single_value() {
+    local out
+    out="$(zsh_env os)"
+    assert_not_equal "" "$out" "os fact should be non-empty"
+}
+
+test_env_query_missing_key_returns_nonzero() {
+    zsh_env nonexistent_key >/dev/null 2>&1
+    assert_not_equal "0" "$?" "unknown key should return nonzero"
+}
+
+register_test "env_snapshot_has_expected_keys" test_env_snapshot_has_expected_keys
+register_test "env_query_returns_single_value" test_env_query_returns_single_value
+register_test "env_query_missing_key_returns_nonzero" test_env_query_missing_key_returns_nonzero

--- a/zshrc
+++ b/zshrc
@@ -306,6 +306,7 @@ if _zsh_startup_use_staggered; then
     load_module paths
     load_module screen      # GNU screen helpers
     load_module doctor      # zsh_doctor health-check
+    load_module env_detect  # zsh_env / zsh_env_snapshot registry
     
     # Tier 2: Credentials & paths (defer in current shell)
     _zsh_load_tier2() {
@@ -367,6 +368,7 @@ else
     load_module databricks
     load_module docker
     load_module doctor
+    load_module env_detect
 
     # Heavy data-platform modules. Defer past first prompt when the
     # user opts in via ZSH_DEFER_DATA_PLATFORM=1. Deferring is not the


### PR DESCRIPTION
Adds a consolidated inspection surface for "what terminal / mode are we in?" questions. Doesn't rip out the scattered checks (too risky for one PR); provides a common API that new consumers can use. Closes #139.