### PR TITLE
feat(diagnostics): fileprovider_status + unwedge for stuck fileproviderd

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -2,6 +2,36 @@
 
 ## Common Issues and Solutions
 
+### JetBrains pinwheels / Finder slow / system feels heavy
+
+Symptom: Finder windows beachball, JetBrains apps stutter, Activity
+Monitor shows `fileproviderd` near the top with high CPU and a long
+ELAPSED time (hours or days).
+
+Cause: a cloud-storage provider's local index (typically iCloud Drive)
+has corrupted or is mid-rebuild and `fileproviderd` is grinding through
+a SQLite VACUUM/reindex with a multi-GB temp spill.
+
+Fix:
+
+```sh
+# 1. See the full picture
+zsh_doctor                  # File providers section flags it
+fileprovider_status         # detail: per-provider DB sizes + spill files
+
+# 2. Try the cheap recovery first — bounce the daemon, watch trajectory
+fileprovider_unwedge        # confirms before sudo killall fileproviderd
+
+# 3. If still wedged after the bounce: toggle iCloud Drive off / on
+#    (System Settings → iCloud → Drive → tap tile → Sync this Mac off,
+#     choose "Keep a Copy", reboot, toggle back on).
+```
+
+The toggle path can't be automated — it requires the GUI. Resist
+suggesting "Optimize Mac Storage" as a follow-up; it has its own sync
+issues. See GitHub issue #161 for the full investigation that produced
+this tooling, and the May 2026 109-hour wedge that motivated it.
+
 ### Test suite flakes with unexplained SIGPIPE / exit 141
 
 Symptom: `tests/test-*.zsh` assertions of the form

--- a/modules/doctor.zsh
+++ b/modules/doctor.zsh
@@ -100,6 +100,34 @@ zsh_doctor() {
     fi
     print -- ""
 
+    print -- "● File providers"
+    local fpd_pid fpd_cpu_int
+    fpd_pid="$(pgrep -x fileproviderd 2>/dev/null || true)"
+    if [[ -z "$fpd_pid" ]]; then
+        _doctor_ok "fileproviderd not running"
+    else
+        fpd_cpu_int="$(ps -p "$fpd_pid" -o %cpu= 2>/dev/null | awk '{printf "%d", $1}')"
+        if (( ${fpd_cpu_int:-0} >= 50 )); then
+            _doctor_fail "fileproviderd at ${fpd_cpu_int}% CPU — run fileprovider_unwedge"
+        elif (( ${fpd_cpu_int:-0} >= 20 )); then
+            _doctor_warn "fileproviderd at ${fpd_cpu_int}% CPU (probably normal sync activity)"
+        else
+            _doctor_ok "fileproviderd at ${fpd_cpu_int}% CPU"
+        fi
+        # Flag any DB > 1 GB
+        local fp_root="$HOME/Library/Application Support/FileProvider"
+        local big_dbs=()
+        local dbf size
+        for dbf in "$fp_root"/*/database/db(N); do
+            size="$(stat -f%z "$dbf" 2>/dev/null || stat -c%s "$dbf" 2>/dev/null || echo 0)"
+            (( size > 1024**3 )) && big_dbs+=("${dbf:h:h:t}")
+        done
+        if (( ${#big_dbs[@]} > 0 )); then
+            _doctor_warn "FileProvider DB > 1 GB on: ${(j:, :)big_dbs}"
+        fi
+    fi
+    print -- ""
+
     print -- "● Modules"
     local loaded=0 available=0 m
     local modules_dir="${ZSHRC_CONFIG_DIR:-$HOME/.config/zsh}/modules"

--- a/modules/fileprovider.zsh
+++ b/modules/fileprovider.zsh
@@ -1,0 +1,159 @@
+#!/usr/bin/env zsh
+# =================================================================
+# FILEPROVIDER — diagnostics for macOS FileProvider daemon wedges
+# =================================================================
+# When iCloud Drive (or another cloud-storage provider) corrupts its
+# local index, /usr/libexec/fileproviderd pegs CPU for hours/days,
+# starves disk I/O, and downstream JetBrains / Finder pinwheel.
+#
+# This module provides:
+#   fileprovider_status  — read-only health check across all providers
+#   fileprovider_check   — wraps `fileproviderctl check` (FPCK)
+#   fileprovider_unwedge — guided recovery (bounce + check + UI fallback)
+#
+# Trigger: if zsh_doctor reports `File providers: WARN` or your shell
+# feels slow + Activity Monitor shows fileproviderd at the top.
+# Saved a 109-hour CPU spinner on 2026-05-06.
+
+# Pretty size for a byte count. Falls through both BSD/GNU stat sites.
+_fp_human_size() {
+    local bytes="${1:-0}"
+    if (( bytes < 1024 )); then printf "%dB" "$bytes"
+    elif (( bytes < 1024**2 )); then printf "%.1fK" "$((bytes / 1024.0))"
+    elif (( bytes < 1024**3 )); then printf "%.1fM" "$((bytes / 1024.0**2))"
+    elif (( bytes < 1024**4 )); then printf "%.1fG" "$((bytes / 1024.0**3))"
+    else printf "%.1fT" "$((bytes / 1024.0**4))"
+    fi
+}
+
+_fp_size_of() {
+    [[ -f "$1" ]] || { echo 0; return 0; }
+    stat -f%z "$1" 2>/dev/null || stat -c%s "$1" 2>/dev/null || echo 0
+}
+
+# Report fileproviderd state + every active provider's local DB size.
+# Flags DB > 1 GB and presence of SQLite spill files. Read-only.
+fileprovider_status() {
+    emulate -L zsh
+    local fpd_pid fpd_cpu fpd_etime
+    fpd_pid="$(pgrep -x fileproviderd 2>/dev/null || true)"
+    if [[ -z "$fpd_pid" ]]; then
+        print -- "fileproviderd: not running"
+        return 0
+    fi
+    fpd_cpu="$(ps -p "$fpd_pid" -o %cpu= 2>/dev/null | tr -d ' ')"
+    fpd_etime="$(ps -p "$fpd_pid" -o etime= 2>/dev/null | tr -d ' ')"
+    print -- "fileproviderd  pid=${fpd_pid}  cpu=${fpd_cpu}%  etime=${fpd_etime}"
+    local cpu_int="${fpd_cpu%.*}"
+    if (( ${cpu_int:-0} >= 50 )); then
+        print -- "  ⚠️  CPU ≥ 50% — provider may be stuck. Run fileprovider_unwedge."
+    fi
+
+    local fp_root="$HOME/Library/Application Support/FileProvider"
+    if [[ ! -d "$fp_root" ]]; then
+        print -- "no provider directory at $fp_root"
+        return 0
+    fi
+    print -- ""
+    print -- "Providers (DB sizes):"
+    local entry name db wal db_size wal_size
+    for entry in "$fp_root"/*(N/); do
+        name="${entry:t}"
+        db="$entry/database/db"
+        wal="$entry/database/db-wal"
+        db_size="$(_fp_size_of "$db")"
+        wal_size="$(_fp_size_of "$wal")"
+        printf "  %-50s db=%-7s wal=%s\n" \
+            "$name" "$(_fp_human_size "$db_size")" "$(_fp_human_size "$wal_size")"
+        if (( db_size > 1024**3 )); then
+            print -- "    ⚠️  DB > 1 GB — likely the wedged provider."
+        fi
+    done
+
+    # SQLite temp spill (the etilqs_ prefix is sqlite reversed).
+    local tmp_dir="${TMPDIR:-/tmp}com.apple.fileproviderd"
+    [[ -d "$tmp_dir" ]] || tmp_dir="/private/var/folders/$(echo "$USER" | head -c2)/$(echo "$USER" | head -c2)/T/com.apple.fileproviderd"
+    local spill_files=()
+    if [[ -d "$tmp_dir" ]]; then
+        spill_files=("$tmp_dir"/etilqs_*(N))
+    fi
+    if (( ${#spill_files[@]} > 0 )); then
+        print -- ""
+        print -- "  ⚠️  SQLite temp spill files present (provider mid-operation):"
+        local f
+        for f in "${spill_files[@]}"; do
+            printf "      %s  (%s)\n" "${f:t}" "$(_fp_human_size "$(_fp_size_of "$f")")"
+        done
+    fi
+}
+
+# Run Apple's FPCK (FileProvider Consistency Check) to detect index
+# corruption. Read-only; reports without modifying.
+fileprovider_check() {
+    emulate -L zsh
+    if ! command -v fileproviderctl >/dev/null 2>&1; then
+        print -u2 -- "fileproviderctl not found — only available on recent macOS"
+        return 1
+    fi
+    print -- "Running fileproviderctl check (this can take a few minutes)..."
+    /usr/bin/fileproviderctl check -P -d "$@"
+}
+
+# Guided recovery for a wedged provider. Walks user through escalating
+# steps with confirmation between each. Never goes further than killing
+# fileproviderd; the toggle-off / reboot / toggle-on sequence is left as
+# manual instructions because it requires GUI interaction.
+fileprovider_unwedge() {
+    emulate -L zsh
+    print -- "fileprovider_unwedge — guided recovery"
+    print -- ""
+    fileprovider_status
+    print -- ""
+
+    local pid cpu_int
+    pid="$(pgrep -x fileproviderd 2>/dev/null || true)"
+    if [[ -z "$pid" ]]; then
+        print -- "fileproviderd not running. Nothing to do."
+        return 0
+    fi
+    cpu_int="$(ps -p "$pid" -o %cpu= 2>/dev/null | awk '{printf "%d", $1}')"
+    if (( cpu_int < 50 )); then
+        print -- "fileproviderd at ${cpu_int}% CPU — looks fine. Skipping bounce."
+        return 0
+    fi
+
+    print -u2 -n -- "Bounce fileproviderd (sudo killall)? [y/N] "
+    local ans
+    read -r ans
+    [[ "$ans" =~ ^[Yy]$ ]] || { print -- "Aborted."; return 1; }
+
+    sudo killall fileproviderd
+    print -- "Killed. Watching trajectory for 60 seconds..."
+    local i new_pid new_cpu
+    for i in 1 2 3 4 5 6; do
+        sleep 10
+        new_pid="$(pgrep -x fileproviderd 2>/dev/null || true)"
+        if [[ -z "$new_pid" ]]; then
+            print -- "  [$(date +%H:%M:%S)] not yet respawned"
+            continue
+        fi
+        new_cpu="$(ps -p "$new_pid" -o %cpu= 2>/dev/null | tr -d ' ')"
+        printf "  [%s] pid=%s cpu=%s%%\n" "$(date +%H:%M:%S)" "$new_pid" "$new_cpu"
+    done
+
+    print -- ""
+    new_cpu="${new_cpu%.*}"
+    if (( ${new_cpu:-0} < 30 )); then
+        print -- "✅ fileproviderd settled to ${new_cpu}% CPU — likely fixed."
+    else
+        print -- "⚠️  fileproviderd still busy after bounce."
+        print -- ""
+        print -- "Next step (manual, GUI required):"
+        print -- "  1. Settings → iCloud → Drive → tap 'Drive' tile"
+        print -- "  2. Toggle 'Sync this Mac' OFF — choose 'Keep a Copy'"
+        print -- "  3. Reboot"
+        print -- "  4. Same toggle back ON — index rebuilds clean"
+        print -- ""
+        print -- "fileprovider_check  — run Apple's FPCK consistency check"
+    fi
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -26,6 +26,7 @@ Minimal zsh test framework and test suites for this repo.
 - `test-doctor.zsh`
 - `test-module-flags.zsh`
 - `test-env-detect.zsh`
+- `test-fileprovider.zsh`
 - `test-backup.zsh`
 - `test-database.zsh`
 - `test-docker.zsh`

--- a/tests/test-fileprovider.zsh
+++ b/tests/test-fileprovider.zsh
@@ -1,0 +1,63 @@
+#!/usr/bin/env zsh
+
+ROOT_DIR="$(cd "$(dirname "${0:A}")/.." && pwd)"
+source "$ROOT_DIR/tests/test-framework.zsh"
+source "$ROOT_DIR/modules/fileprovider.zsh"
+
+test_fileprovider_status_runs() {
+    local out
+    out="$(fileprovider_status 2>&1)"
+    # Either daemon is running (and we see fileproviderd line) or it's not
+    # (and we see "not running"). Either is a healthy run.
+    if [[ "$out" != *"fileproviderd"* ]]; then
+        _print_fail "expected output to mention fileproviderd; got: $out"
+        return 1
+    fi
+    return 0
+}
+
+test_fp_human_size_thresholds() {
+    assert_equal "0B" "$(_fp_human_size 0)" "0 → 0B"
+    assert_equal "512B" "$(_fp_human_size 512)" "512 → 512B"
+    assert_equal "1.0K" "$(_fp_human_size 1024)" "1KiB → 1.0K"
+    assert_equal "1.0M" "$(_fp_human_size 1048576)" "1MiB → 1.0M"
+    assert_equal "1.0G" "$(_fp_human_size 1073741824)" "1GiB → 1.0G"
+}
+
+test_fp_size_of_handles_missing_file() {
+    local out
+    out="$(_fp_size_of "/no/such/path")"
+    assert_equal "0" "$out" "missing file should return 0"
+}
+
+test_fp_size_of_real_file() {
+    local tmp
+    tmp="$(mktemp)"
+    print -- "12345" > "$tmp"
+    local out
+    out="$(_fp_size_of "$tmp")"
+    rm -f "$tmp"
+    assert_equal "6" "$out" "6 bytes (5 chars + newline)"
+}
+
+test_fileprovider_check_handles_missing_ctl() {
+    # If /usr/bin/fileproviderctl is not on PATH, the function should
+    # warn and return nonzero rather than blow up.
+    local saved_path="$PATH"
+    PATH="/tmp/empty-bin"
+    local out rc
+    out="$(fileprovider_check 2>&1 || true)"
+    rc=$?
+    PATH="$saved_path"
+    if [[ "$out" != *"fileproviderctl not found"* ]]; then
+        _print_fail "expected 'fileproviderctl not found' message; got: $out"
+        return 1
+    fi
+    return 0
+}
+
+register_test "fileprovider_status_runs" test_fileprovider_status_runs
+register_test "fp_human_size_thresholds" test_fp_human_size_thresholds
+register_test "fp_size_of_handles_missing_file" test_fp_size_of_handles_missing_file
+register_test "fp_size_of_real_file" test_fp_size_of_real_file
+register_test "fileprovider_check_handles_missing_ctl" test_fileprovider_check_handles_missing_ctl

--- a/wiki/Functions-Index.md
+++ b/wiki/Functions-Index.md
@@ -176,6 +176,14 @@ their source order. Underscore-prefixed helpers are included.
 - `zsh_env_snapshot`
 - `zsh_env`
 
+## `modules/fileprovider.zsh`
+
+- `_fp_human_size`
+- `_fp_size_of`
+- `fileprovider_status`
+- `fileprovider_check`
+- `fileprovider_unwedge`
+
 ## `modules/github.zsh`
 
 - `_gh_usage`

--- a/zshrc
+++ b/zshrc
@@ -305,8 +305,9 @@ if _zsh_startup_use_staggered; then
     load_module agents
     load_module paths
     load_module screen      # GNU screen helpers
-    load_module doctor      # zsh_doctor health-check
-    load_module env_detect  # zsh_env / zsh_env_snapshot registry
+    load_module doctor       # zsh_doctor health-check
+    load_module env_detect   # zsh_env / zsh_env_snapshot registry
+    load_module fileprovider # fileprovider_status / unwedge for stuck fileproviderd
     
     # Tier 2: Credentials & paths (defer in current shell)
     _zsh_load_tier2() {
@@ -369,6 +370,7 @@ else
     load_module docker
     load_module doctor
     load_module env_detect
+    load_module fileprovider
 
     # Heavy data-platform modules. Defer past first prompt when the
     # user opts in via ZSH_DEFER_DATA_PLATFORM=1. Deferring is not the


### PR DESCRIPTION
Closes #161.

Triggered by today's 109-hour fileproviderd CPU wedge on iCloud Drive. The recovery dance (lsof, fs_usage, kill, watch, toggle, reboot) became muscle memory but was slow to walk through manually. This wraps it.

## What's added

- `modules/fileprovider.zsh`:
  - `fileprovider_status` — read-only diagnostic: fileproviderd CPU, per-provider DB sizes, SQLite temp-spill detection. Flags DB > 1 GB.
  - `fileprovider_check` — wraps `/usr/bin/fileproviderctl check` (Apple's FPCK consistency check).
  - `fileprovider_unwedge` — guided recovery. Prompts before sudo killall, watches CPU trajectory for 60s, declares fix or prints the manual UI-toggle recipe. Never goes nuclear without explicit user action.

- `zsh_doctor` gains a `● File providers` section: FAIL on ≥50% CPU, WARN on ≥20%, flags any DB > 1 GB.

- `TROUBLESHOOTING.md`: 'JetBrains pinwheels / Finder slow' entry with the recipe.

- 5 unit tests (status runs, size formatter, missing-file handling, missing-fileproviderctl graceful fallback).

## Test plan
- [x] `make test` green (3 pre-existing env failures unrelated)
- [x] Function index regenerated
- [x] `fileprovider_status` runs cleanly on the post-rebuild iCloud Drive (3.9 MB DB, healthy CPU)
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guide for JetBrains and Finder slowness caused by file provider issues, with diagnostic and recovery steps.

* **New Features**
  * Added file provider health diagnostics and automated recovery tools to detect and resolve system performance issues related to cloud storage indexing.

* **Tests**
  * Added comprehensive test coverage for file provider diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->