### PR TITLE
chore(vars): add SIEGE_CHORD_LIBRARY env var

### DIFF
--- a/vars.mac.env
+++ b/vars.mac.env
@@ -47,6 +47,7 @@ export SIEGE="${SIEGE:-$PROFESSIONAL/Siege_Analytics}"
 export SIEGE_CLIENTS="${SIEGE_CLIENTS:-$SIEGE/Clients}"
 export SIEGE_CODE="${SIEGE_CODE:-$SIEGE/Code}"
 export SIEGE_UTILITIES="${SIEGE_UTILITIES:-$SIEGE_CODE/siege_utilities}"
+export SIEGE_CHORD_LIBRARY="${SIEGE_CHORD_LIBRARY:-$SIEGE_CODE/music/musescore4-chord-library-plugin}"
 
 # Suzy
 export SUZY="${SUZY:-$SIEGE_CLIENTS/Suzy}"


### PR DESCRIPTION
Points at the musescore4 chord-library plugin checkout under $SIEGE_CODE/music. Mirrors SIEGE_UTILITIES.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added chord library support for macOS with preconfigured default paths, enabling seamless access to chord library functionality on macOS systems.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dheerajchand/siege_analytics_zshrc/pull/163)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->