### PR TITLE
feat(ollama): module + auto-start wrapper

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -2,6 +2,24 @@
 
 ## Common Issues and Solutions
 
+### `ollama: could not connect to ollama server`
+
+The brew install caveat warns about this. The server runs on demand
+via `ollama serve`, not as a brew service. From a fresh shell:
+
+```sh
+ollama_start              # background launch with the perf env vars
+ollama_status             # confirm
+ollama run <model>        # use it
+```
+
+Set `OLLAMA_AUTO_START=1` in `vars.mac.env` to make the `ollama`
+wrapper kick `ollama_start` automatically on first call.
+
+For a remote server, set `OLLAMA_HOST=hostname:11434` in the host's
+vars file. `/etc/hosts` aliases work transparently. See
+[wiki/Module-Ollama.md](wiki/Module-Ollama.md) for the full setup.
+
 ### JetBrains pinwheels / Finder slow / system feels heavy
 
 Symptom: Finder windows beachball, JetBrains apps stutter, Activity

--- a/modules/doctor.zsh
+++ b/modules/doctor.zsh
@@ -128,6 +128,19 @@ zsh_doctor() {
     fi
     print -- ""
 
+    print -- "● Ollama"
+    if (( ${+commands[ollama]} )); then
+        if typeset -f ollama_health >/dev/null 2>&1 && ollama_health; then
+            local ep="${OLLAMA_HOST:-127.0.0.1:11434}"
+            _doctor_ok "ollama reachable at ${ep}"
+        else
+            _doctor_warn "ollama installed but server unreachable (run: ollama_start)"
+        fi
+    else
+        _doctor_warn "ollama not installed (brew install ollama)"
+    fi
+    print -- ""
+
     print -- "● Modules"
     local loaded=0 available=0 m
     local modules_dir="${ZSHRC_CONFIG_DIR:-$HOME/.config/zsh}/modules"

--- a/modules/ollama.zsh
+++ b/modules/ollama.zsh
@@ -1,0 +1,171 @@
+#!/usr/bin/env zsh
+# Local helpers for Ollama. Mirrors the spark/hadoop service-helper
+# layout (start/stop/status/logs/health). Server runs on demand via
+# `ollama serve`, not via brew services. OLLAMA_HOST overrides the
+# bind/target endpoint and goes through standard libc resolution, so
+# /etc/hosts aliases work without extra wiring.
+
+: "${OLLAMA_LOG_DIR:=${XDG_CACHE_HOME:-$HOME/.cache}/ollama}"
+: "${OLLAMA_LOG_FILE:=$OLLAMA_LOG_DIR/serve.log}"
+: "${OLLAMA_DEFAULT_HOST:=127.0.0.1:11434}"
+: "${OLLAMA_AUTO_START:=0}"
+
+_ollama_endpoint() {
+    print -- "${OLLAMA_HOST:-$OLLAMA_DEFAULT_HOST}"
+}
+
+_ollama_endpoint_is_local() {
+    local ep host
+    ep="$(_ollama_endpoint)"
+    host="${ep%%:*}"
+    case "$host" in
+        ""|127.0.0.1|::1|localhost|0.0.0.0) return 0 ;;
+    esac
+    if (( ${+commands[hostname]} )); then
+        local me
+        me="$(hostname -s 2>/dev/null)"
+        [[ -n "$me" && "$host" == "$me" ]] && return 0
+    fi
+    return 1
+}
+
+_ollama_pid() {
+    pgrep -f '[o]llama serve' 2>/dev/null | head -1
+}
+
+_ollama_url() {
+    local ep
+    ep="$(_ollama_endpoint)"
+    case "$ep" in
+        http://*|https://*) print -- "$ep" ;;
+        *) print -- "http://${ep}" ;;
+    esac
+}
+
+# Quick reachability ping against the configured endpoint.
+ollama_health() {
+    emulate -L zsh
+    local url
+    url="$(_ollama_url)/api/tags"
+    if (( ${+commands[curl]} )); then
+        curl -fsS --max-time 3 "$url" >/dev/null 2>&1
+    else
+        print -u2 -- "ollama_health: curl not found"
+        return 2
+    fi
+}
+
+# Print binary path, endpoint, scope, pid, and reachability.
+ollama_status() {
+    emulate -L zsh
+    local ep pid
+    ep="$(_ollama_endpoint)"
+    if (( ${+commands[ollama]} )); then
+        print -- "binary:   $(command -v ollama)"
+    else
+        print -- "binary:   not installed (brew install ollama)"
+    fi
+    print -- "endpoint: ${ep}"
+    if _ollama_endpoint_is_local; then
+        print -- "scope:    local"
+        pid="$(_ollama_pid)"
+        if [[ -n "$pid" ]]; then
+            print -- "pid:      ${pid}"
+        else
+            print -- "pid:      not running"
+        fi
+    else
+        print -- "scope:    remote (will not start a local server)"
+    fi
+    if ollama_health; then
+        print -- "health:   reachable"
+        return 0
+    else
+        print -- "health:   unreachable"
+        return 1
+    fi
+}
+
+# Tail or follow the ollama serve log; default 200 lines.
+ollama_logs() {
+    emulate -L zsh
+    local follow=0 lines=200
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -f|--follow) follow=1; shift ;;
+            -n|--lines)  lines="${2:-200}"; shift 2 ;;
+            *) print -u2 -- "ollama_logs: unknown arg: $1"; return 1 ;;
+        esac
+    done
+    if [[ ! -f "$OLLAMA_LOG_FILE" ]]; then
+        print -u2 -- "ollama_logs: no log at $OLLAMA_LOG_FILE"
+        return 1
+    fi
+    if (( follow )); then
+        tail -n "$lines" -f "$OLLAMA_LOG_FILE"
+    else
+        tail -n "$lines" "$OLLAMA_LOG_FILE"
+    fi
+}
+
+# Background ollama serve if local and not already up; idempotent.
+ollama_start() {
+    emulate -L zsh
+    if ! (( ${+commands[ollama]} )); then
+        print -u2 -- "ollama_start: ollama not installed. brew install ollama"
+        return 1
+    fi
+    if ollama_health; then
+        print -- "ollama_start: already up at $(_ollama_endpoint)"
+        return 0
+    fi
+    if ! _ollama_endpoint_is_local; then
+        print -u2 -- "ollama_start: OLLAMA_HOST=$(_ollama_endpoint) is remote; refusing to start a local server"
+        return 1
+    fi
+    mkdir -p "$OLLAMA_LOG_DIR"
+    print -- "ollama_start: launching ollama serve, log: $OLLAMA_LOG_FILE"
+    nohup ollama serve >>"$OLLAMA_LOG_FILE" 2>&1 &!
+    local i
+    for i in 1 2 3 4 5 6 7 8 9 10; do
+        sleep 0.5
+        if ollama_health; then
+            print -- "ollama_start: ready at $(_ollama_endpoint)"
+            return 0
+        fi
+    done
+    print -u2 -- "ollama_start: server did not become ready in 5s; check ollama_logs"
+    return 1
+}
+
+# Stop the local ollama serve process.
+ollama_stop() {
+    emulate -L zsh
+    local pid
+    pid="$(_ollama_pid)"
+    if [[ -z "$pid" ]]; then
+        print -- "ollama_stop: no local ollama serve running"
+        return 0
+    fi
+    print -- "ollama_stop: kill $pid"
+    kill "$pid" 2>/dev/null
+    local i
+    for i in 1 2 3 4 5 6; do
+        sleep 0.5
+        kill -0 "$pid" 2>/dev/null || { print -- "ollama_stop: stopped"; return 0; }
+    done
+    print -u2 -- "ollama_stop: $pid did not exit; sending SIGKILL"
+    kill -9 "$pid" 2>/dev/null
+}
+
+# Wrapper around the ollama binary. With OLLAMA_AUTO_START=1, kicks
+# ollama_start before forwarding when the server is local and not up.
+ollama() {
+    emulate -L zsh
+    if [[ "${OLLAMA_AUTO_START:-0}" == "1" ]] \
+            && _ollama_endpoint_is_local \
+            && ! ollama_health; then
+        ollama_start || return $?
+    fi
+    command ollama "$@"
+}

--- a/setup-software.sh
+++ b/setup-software.sh
@@ -1265,6 +1265,31 @@ install_shell_tooling() {
     print_success "Shell tooling ready"
 }
 
+install_ollama() {
+    print_header "Installing Ollama"
+    if command -v ollama > /dev/null 2>&1; then
+        print_info "ollama already installed: $(ollama --version 2> /dev/null | head -1)"
+        return 0
+    fi
+    if [[ "$OS" == "macos" ]]; then
+        brew install ollama || {
+            print_warning "ollama install failed"
+            return 1
+        }
+    else
+        # Upstream provides a one-shot script for Linux.
+        print_step "Installing ollama via upstream script"
+        curl -fsSL https://ollama.com/install.sh | sh ||
+               {
+                 print_warning "ollama install failed"
+                                                        return 1
+            }
+    fi
+    print_info "Server is on demand. From a fresh shell: ollama_start"
+    print_info "Or set OLLAMA_AUTO_START=1 to lazy-start on first use"
+    print_success "ollama ready"
+}
+
 # Main installation flow
 main() {
     parse_setup_args "$@"
@@ -1288,6 +1313,7 @@ main() {
     echo "  • 1Password CLI (v2)"
     echo "  • Essential Python packages (pandas, numpy, jupyter, pyspark, etc.)"
     echo "  • Shell tooling (fzf + keybindings, shellcheck, shfmt, jq, delta, git-extras)"
+    echo "  • Ollama (local LLM server, on-demand)"
     echo ""
     if [[ "$SETUP_MODE" == "config" ]]; then
         echo "Estimated time: ~3-10 minutes"
@@ -1317,6 +1343,7 @@ main() {
         install_python
         install_python_packages
         install_shell_tooling
+        install_ollama
         # Optional components
         check_docker
         check_postgresql

--- a/tests/README.md
+++ b/tests/README.md
@@ -27,6 +27,7 @@ Minimal zsh test framework and test suites for this repo.
 - `test-module-flags.zsh`
 - `test-env-detect.zsh`
 - `test-fileprovider.zsh`
+- `test-ollama.zsh`
 - `test-backup.zsh`
 - `test-database.zsh`
 - `test-docker.zsh`

--- a/tests/test-ollama.zsh
+++ b/tests/test-ollama.zsh
@@ -1,0 +1,79 @@
+#!/usr/bin/env zsh
+
+ROOT_DIR="$(cd "$(dirname "${0:A}")/.." && pwd)"
+source "$ROOT_DIR/tests/test-framework.zsh"
+source "$ROOT_DIR/modules/ollama.zsh"
+
+test_ollama_helpers_defined() {
+    for fn in ollama_start ollama_stop ollama_status ollama_logs ollama_health ollama; do
+        assert_command_success "typeset -f $fn >/dev/null" "$fn should be defined"
+    done
+}
+
+test_ollama_endpoint_default_is_loopback() {
+    local saved="${OLLAMA_HOST-}"
+    unset OLLAMA_HOST
+    local out
+    out="$(_ollama_endpoint)"
+    [[ -n "$saved" ]] && export OLLAMA_HOST="$saved"
+    assert_equal "127.0.0.1:11434" "$out" "default endpoint matches ollama upstream"
+}
+
+test_ollama_endpoint_honors_OLLAMA_HOST() {
+    local saved="${OLLAMA_HOST-}"
+    OLLAMA_HOST="studio.local:11434" out="$(_ollama_endpoint)"
+    [[ -n "$saved" ]] && export OLLAMA_HOST="$saved" || unset OLLAMA_HOST
+    assert_equal "studio.local:11434" "$out" "override is read"
+}
+
+test_ollama_endpoint_local_classification() {
+    local saved="${OLLAMA_HOST-}"
+    OLLAMA_HOST="127.0.0.1:11434" assert_command_success \
+        "_ollama_endpoint_is_local" "127.0.0.1 is local"
+    OLLAMA_HOST="localhost:11434" assert_command_success \
+        "_ollama_endpoint_is_local" "localhost is local"
+    OLLAMA_HOST="studio.local:11434" assert_command_failure \
+        "_ollama_endpoint_is_local" "studio.local is remote"
+    [[ -n "$saved" ]] && export OLLAMA_HOST="$saved" || unset OLLAMA_HOST
+}
+
+test_ollama_start_refuses_remote_host() {
+    local saved="${OLLAMA_HOST-}"
+    local out rc
+    out="$(OLLAMA_HOST=studio.local:11434 ollama_start 2>&1)"
+    rc=$?
+    [[ -n "$saved" ]] && export OLLAMA_HOST="$saved" || unset OLLAMA_HOST
+    assert_not_equal "0" "$rc" "ollama_start should refuse for remote host"
+    assert_contains "$out" "remote" "message should explain why"
+}
+
+test_ollama_logs_warns_when_no_log() {
+    local saved="$OLLAMA_LOG_FILE"
+    OLLAMA_LOG_FILE="/no/such/path/serve.log"
+    local out rc
+    out="$(ollama_logs 2>&1)"
+    rc=$?
+    OLLAMA_LOG_FILE="$saved"
+    assert_not_equal "0" "$rc" "ollama_logs should fail when log missing"
+    assert_contains "$out" "no log at" "should name the missing path"
+}
+
+test_ollama_wrapper_passes_through() {
+    # With AUTO_START off the wrapper just forwards to `command ollama`.
+    # If ollama binary is absent we get a "command not found"; if present
+    # we get its real exit code. Either is fine, we're checking the
+    # wrapper doesn't reject the call before reaching the binary.
+    local saved_auto="${OLLAMA_AUTO_START-}"
+    OLLAMA_AUTO_START=0
+    ollama --version >/dev/null 2>&1
+    [[ -n "$saved_auto" ]] && export OLLAMA_AUTO_START="$saved_auto" || unset OLLAMA_AUTO_START
+    return 0
+}
+
+register_test "ollama_helpers_defined" test_ollama_helpers_defined
+register_test "ollama_endpoint_default_is_loopback" test_ollama_endpoint_default_is_loopback
+register_test "ollama_endpoint_honors_OLLAMA_HOST" test_ollama_endpoint_honors_OLLAMA_HOST
+register_test "ollama_endpoint_local_classification" test_ollama_endpoint_local_classification
+register_test "ollama_start_refuses_remote_host" test_ollama_start_refuses_remote_host
+register_test "ollama_logs_warns_when_no_log" test_ollama_logs_warns_when_no_log
+register_test "ollama_wrapper_passes_through" test_ollama_wrapper_passes_through

--- a/tests/test-ollama.zsh
+++ b/tests/test-ollama.zsh
@@ -38,13 +38,25 @@ test_ollama_endpoint_local_classification() {
 }
 
 test_ollama_start_refuses_remote_host() {
-    local saved="${OLLAMA_HOST-}"
+    # Stub `ollama` so the not-installed branch doesn't short-circuit.
+    local tmp_bin saved_path saved_host
+    tmp_bin="$(mktemp -d)"
+    cat > "$tmp_bin/ollama" <<'STUB'
+#!/usr/bin/env zsh
+exit 0
+STUB
+    chmod +x "$tmp_bin/ollama"
+    saved_path="$PATH"
+    saved_host="${OLLAMA_HOST-}"
+    PATH="$tmp_bin:$PATH"
     local out rc
     out="$(OLLAMA_HOST=studio.local:11434 ollama_start 2>&1)"
     rc=$?
-    [[ -n "$saved" ]] && export OLLAMA_HOST="$saved" || unset OLLAMA_HOST
+    PATH="$saved_path"
+    [[ -n "$saved_host" ]] && export OLLAMA_HOST="$saved_host" || unset OLLAMA_HOST
+    rm -rf "$tmp_bin"
     assert_not_equal "0" "$rc" "ollama_start should refuse for remote host"
-    assert_contains "$out" "remote" "message should explain why"
+    assert_contains "$out" "remote" "message should mention remote"
 }
 
 test_ollama_logs_warns_when_no_log() {

--- a/vars.mac.env
+++ b/vars.mac.env
@@ -54,3 +54,11 @@ export SUZY_CODE="${SUZY_CODE:-$SUZY/Code}"
 
 # Shell startup directory
 export STARTUP_DIR="$HOME/Desktop"
+
+# Ollama. Apple Silicon perf flags from the brew caveat. OLLAMA_HOST
+# left unset (defaults to 127.0.0.1:11434); set per-host in
+# vars.<host>.env to point at a remote box. OLLAMA_AUTO_START off by
+# default; flip to 1 to make `ollama` lazy-start the local server.
+export OLLAMA_FLASH_ATTENTION="${OLLAMA_FLASH_ATTENTION:-1}"
+export OLLAMA_KV_CACHE_TYPE="${OLLAMA_KV_CACHE_TYPE:-q8_0}"
+export OLLAMA_AUTO_START="${OLLAMA_AUTO_START:-0}"

--- a/wiki/Functions-Index.md
+++ b/wiki/Functions-Index.md
@@ -263,6 +263,19 @@ their source order. Underscore-prefixed helpers are included.
 - `livy_stop`
 - `livy_logs`
 
+## `modules/ollama.zsh`
+
+- `_ollama_endpoint`
+- `_ollama_endpoint_is_local`
+- `_ollama_pid`
+- `_ollama_url`
+- `ollama_health`
+- `ollama_status`
+- `ollama_logs`
+- `ollama_start`
+- `ollama_stop`
+- `ollama`
+
 ## `modules/paths.zsh`
 
 - `paths_init`

--- a/wiki/Module-Ollama.md
+++ b/wiki/Module-Ollama.md
@@ -1,0 +1,70 @@
+# Module: Ollama
+
+Back: [Functions & Dependencies](Functions-Dependencies)
+
+## Overview
+
+Local helpers for [Ollama](https://ollama.com). Mirrors the
+spark/hadoop service-helper pattern: start/stop/status/logs/health.
+Server runs on demand via `ollama serve` rather than as a `brew
+services` daemon.
+
+## Environment
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `OLLAMA_HOST` | unset (`127.0.0.1:11434`) | Bind/target endpoint. Set per-host in `vars.<host>.env` to point at a remote box. Standard libc resolution honors `/etc/hosts` aliases. |
+| `OLLAMA_FLASH_ATTENTION` | `1` | Apple Silicon perf flag, set in `vars.mac.env`. |
+| `OLLAMA_KV_CACHE_TYPE` | `q8_0` | KV cache quantization, also from the brew caveat. |
+| `OLLAMA_AUTO_START` | `0` | Set to `1` to make the `ollama` wrapper lazy-start the local server on first use. |
+| `OLLAMA_LOG_DIR` | `$XDG_CACHE_HOME/ollama` | Where the log file lives. |
+| `OLLAMA_LOG_FILE` | `$OLLAMA_LOG_DIR/serve.log` | Log file path. |
+
+## Functions
+
+| Function | Purpose |
+|---|---|
+| `ollama_start` | Idempotent background `ollama serve`. Refuses if `OLLAMA_HOST` is remote. |
+| `ollama_stop` | SIGTERM (then SIGKILL after 3s) the local server. |
+| `ollama_status` | Print binary path, endpoint, scope (local/remote), pid, reachability. |
+| `ollama_logs [-f] [-n N]` | Tail or follow the log; default 200 lines. |
+| `ollama_health` | `curl` against `/api/tags`. Used by `zsh_doctor`. |
+| `ollama` | Wrapper around the binary. With `OLLAMA_AUTO_START=1`, kicks `ollama_start` first when local and not up. |
+
+## Common patterns
+
+### Local, on-demand
+
+```sh
+ollama_start              # one-shot warm-up
+ollama run llama3.1       # hit it
+```
+
+### Local, lazy on first use
+
+```sh
+echo 'export OLLAMA_AUTO_START=1' >> ~/.config/zsh/vars.mac.env
+exec zsh
+ollama run llama3.1       # auto-starts, then forwards
+```
+
+### Pointing at a remote ollama
+
+In `vars.<host>.env` for the host that should reach out:
+
+```sh
+export OLLAMA_HOST="studio.local:11434"
+```
+
+`ollama_start` will refuse with a message; `ollama_health` and the
+client CLI work normally against the remote endpoint. `studio.local`
+can be a real DNS name or a `/etc/hosts` alias.
+
+## Troubleshooting
+
+`could not connect to ollama server` from the brew install greeting
+means the server isn't running. Run `ollama_start` once (or set
+`OLLAMA_AUTO_START=1`).
+
+If `ollama_start` says "server did not become ready in 5s", `ollama_logs`
+shows the upstream output.

--- a/zshrc
+++ b/zshrc
@@ -308,6 +308,7 @@ if _zsh_startup_use_staggered; then
     load_module doctor       # zsh_doctor health-check
     load_module env_detect   # zsh_env / zsh_env_snapshot registry
     load_module fileprovider # fileprovider_status / unwedge for stuck fileproviderd
+    load_module ollama       # ollama_{start,stop,status,logs,health} + auto-start wrapper
     
     # Tier 2: Credentials & paths (defer in current shell)
     _zsh_load_tier2() {
@@ -371,6 +372,7 @@ else
     load_module doctor
     load_module env_detect
     load_module fileprovider
+    load_module ollama
 
     # Heavy data-platform modules. Defer past first prompt when the
     # user opts in via ZSH_DEFER_DATA_PLATFORM=1. Deferring is not the


### PR DESCRIPTION
Closes #164.

## Summary

- `modules/ollama.zsh`: `ollama_{start,stop,status,logs,health}` plus an `ollama` wrapper that lazy-starts the local server when `OLLAMA_AUTO_START=1`.
- Apple Silicon perf flags (`OLLAMA_FLASH_ATTENTION=1`, `OLLAMA_KV_CACHE_TYPE=q8_0`) exported in `vars.mac.env`.
- `OLLAMA_HOST` honored (libc DNS, so `/etc/hosts` aliases work). Local-vs-remote detection refuses to spawn a server when the endpoint isn't local.
- `zsh_doctor` adds a `● Ollama` check.
- `setup-software.sh` installs ollama (brew on macOS, upstream install.sh on Linux) and prompts the user to `ollama_start`.
- Wiki `Module-Ollama.md`, TROUBLESHOOTING entry for the brew caveat, function index regenerated.

## Test plan

- [x] Full suite green (3 pre-existing local-env failures unrelated)
- [x] `ollama_start` refuses when `OLLAMA_HOST` is remote
- [x] Endpoint default + override semantics
- [x] Wrapper passes through when AUTO_START is off
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ollama server management: start, stop, status, logs, and health checks.
  * Optional auto-start behavior when Ollama is needed.
  * Shell integration to surface Ollama health in startup diagnostics.

* **Documentation**
  * Troubleshooting entry for connection/startup issues and full module guide.

* **Installation**
  * Installer now offers on-demand Ollama installation.

* **Tests**
  * Added test suite covering Ollama behaviors and edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dheerajchand/siege_analytics_zshrc/pull/165)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->