### PR TITLE
feat(secrets,help): zsh_help filter + --help on op_* surface (#168)

### DIFF
--- a/modules/secrets/1password-cli.zsh
+++ b/modules/secrets/1password-cli.zsh
@@ -46,7 +46,93 @@ _op_account_alias_for_uuid() {
     return 1
 }
 
+# Per-function help printer for the public op_* surface. Invoked by
+# each op_* function's leading -h/--help guard. Keeps each public
+# function's own body uncluttered by a multi-line heredoc.
+_op_print_help() {
+    case "$1" in
+        op_accounts_edit) cat <<'EOF'
+Usage: op_accounts_edit
+Open the 1Password account-aliases file ($OP_ACCOUNTS_FILE) in $EDITOR.
+Creates the file from the example if missing.
+EOF
+            ;;
+        op_accounts_sanitize) cat <<'EOF'
+Usage: op_accounts_sanitize [--fix]
+Validate the account-aliases file: drop blanks/comments, dedupe, sort.
+Default is check-only; --fix rewrites the file in place.
+EOF
+            ;;
+        op_accounts_set_alias) cat <<'EOF'
+Usage: op_accounts_set_alias <alias> <account-uuid>
+Append/update <alias>=<account-uuid> in the aliases file.
+Alias must be alphanumeric/underscore.
+EOF
+            ;;
+        op_accounts_seed) cat <<'EOF'
+Usage: op_accounts_seed
+Interactively prompt for an alias for each 1Password account on the device.
+Requires an interactive shell and the op CLI signed in.
+EOF
+            ;;
+        op_verify_accounts) cat <<'EOF'
+Usage: op_verify_accounts
+For each alias in the aliases file, sign in (cached) and run a smoke
+read to confirm credentials work. Reports pass/fail per alias.
+EOF
+            ;;
+        op_set_default) cat <<'EOF'
+Usage: op_set_default <account-uuid-or-shorthand> [vault]
+Export OP_ACCOUNT (and OP_VAULT if given) for this shell. Without args
+prints the current defaults.
+EOF
+            ;;
+        op_list_accounts_vaults) cat <<'EOF'
+Usage: op_list_accounts_vaults
+List all configured 1Password accounts and the vaults visible in each.
+EOF
+            ;;
+        op_list_items) cat <<'EOF'
+Usage: op_list_items [account] [vault] [filter-regex]
+List items in the given account/vault. Defaults to $OP_ACCOUNT/$OP_VAULT.
+Optional filter is a case-insensitive regex applied to item titles.
+EOF
+            ;;
+        op_find_item_across_accounts) cat <<'EOF'
+Usage: op_find_item_across_accounts <title>
+Search every configured 1Password account for items whose title
+exactly matches <title>. Prints account UUID + item id + vault for hits.
+EOF
+            ;;
+        op_signin_account) cat <<'EOF'
+Usage: op_signin_account <account-alias>
+Sign in to a single account by alias and export its OP_SESSION_* token
+into the current shell.
+EOF
+            ;;
+        op_signin_all) cat <<'EOF'
+Usage: op_signin_all
+Sign in to every alias in the aliases file and write the session tokens
+to $OP_SESSIONS_FILE (mode 600). Source with op_sessions_source.
+EOF
+            ;;
+        op_sessions_source) cat <<'EOF'
+Usage: op_sessions_source
+Load OP_SESSION_* exports from $OP_SESSIONS_FILE into the current shell.
+Run op_signin_all first to populate the file.
+EOF
+            ;;
+        op_set_default_alias) cat <<'EOF'
+Usage: op_set_default_alias <account-alias> [vault]
+Resolve <account-alias> via the aliases file, then call op_set_default.
+EOF
+            ;;
+        *) echo "Usage: $1 (no help registered)" >&2; return 1 ;;
+    esac
+}
+
 op_accounts_edit() {
+    case "${1:-}" in -h|--help) _op_print_help op_accounts_edit; return 0 ;; esac
     local editor="${EDITOR:-vi}"
     if [[ ! -f "$OP_ACCOUNTS_FILE" ]]; then
         umask 077
@@ -60,6 +146,7 @@ op_accounts_edit() {
 }
 
 op_accounts_sanitize() {
+    case "${1:-}" in -h|--help) _op_print_help op_accounts_sanitize; return 0 ;; esac
     local mode="check"
     local file="${OP_ACCOUNTS_FILE:-}"
     if [[ "${1:-}" == "--fix" ]]; then
@@ -230,6 +317,7 @@ _op_resolve_account_arg() {
 }
 
 op_accounts_set_alias() {
+    case "${1:-}" in -h|--help) _op_print_help op_accounts_set_alias; return 0 ;; esac
     local alias_name="${1:-}"
     local uuid="${2:-}"
     if [[ -z "$alias_name" || -z "$uuid" ]]; then
@@ -245,6 +333,7 @@ op_accounts_set_alias() {
 }
 
 op_accounts_seed() {
+    case "${1:-}" in -h|--help) _op_print_help op_accounts_seed; return 0 ;; esac
     _secrets_require_op "cannot seed aliases" || return 1
     if [[ -z "${ZSH_TEST_MODE:-}" && ! -o interactive ]]; then
         _secrets_warn "Interactive shell required to seed aliases"
@@ -286,6 +375,7 @@ PY
 }
 
 op_verify_accounts() {
+    case "${1:-}" in -h|--help) _op_print_help op_verify_accounts; return 0 ;; esac
     local rc=0
     (
         emulate -L zsh -o no_xtrace -o no_verbose
@@ -456,6 +546,7 @@ PY
 }
 
 op_set_default() {
+    case "${1:-}" in -h|--help) _op_print_help op_set_default; return 0 ;; esac
     local account="${1:-}"
     local vault="${2:-}"
     if [[ -n "$vault" && -z "$account" ]]; then
@@ -488,6 +579,7 @@ op_set_default() {
 }
 
 op_list_accounts_vaults() {
+    case "${1:-}" in -h|--help) _op_print_help op_list_accounts_vaults; return 0 ;; esac
     _secrets_require_op "cannot list accounts/vaults" || return 1
     local accounts_json
     accounts_json="$(op account list --format=json 2>/dev/null)"
@@ -545,6 +637,7 @@ PY
 }
 
 op_list_items() {
+    case "${1:-}" in -h|--help) _op_print_help op_list_items; return 0 ;; esac
     local account_arg="${1:-${OP_ACCOUNT-}}"
     local vault_arg="${2:-${OP_VAULT-}}"
     local filter="${3:-}"
@@ -599,6 +692,7 @@ PY
 }
 
 op_find_item_across_accounts() {
+    case "${1:-}" in -h|--help) _op_print_help op_find_item_across_accounts; return 0 ;; esac
     local title="${1:-}"
     if [[ -z "$title" ]]; then
         _secrets_warn "Usage: op_find_item_across_accounts <title>"
@@ -652,6 +746,7 @@ PY
 }
 
 op_signin_account() {
+    case "${1:-}" in -h|--help) _op_print_help op_signin_account; return 0 ;; esac
     local account_alias="${1:-}"
     if [[ -z "$account_alias" ]]; then
         echo "Usage: op_signin_account <account-alias>" >&2
@@ -683,6 +778,7 @@ op_signin_account() {
 }
 
 op_signin_all() {
+    case "${1:-}" in -h|--help) _op_print_help op_signin_all; return 0 ;; esac
     setopt local_options
     unsetopt xtrace verbose
     if ! command -v op >/dev/null 2>&1; then
@@ -819,6 +915,7 @@ _op_sessions_save() {
 }
 
 op_sessions_source() {
+    case "${1:-}" in -h|--help) _op_print_help op_sessions_source; return 0 ;; esac
     local sessions_file="${OP_SESSIONS_FILE:-$HOME/.config/zsh/.op-sessions.env}"
     if [[ ! -f "$sessions_file" ]]; then
         _secrets_warn "No sessions file: $sessions_file (run op_signin_all first)"
@@ -835,6 +932,7 @@ op_sessions_source() {
 }
 
 op_set_default_alias() {
+    case "${1:-}" in -h|--help) _op_print_help op_set_default_alias; return 0 ;; esac
     local account_alias="${1:-}"
     local vault="${2:-}"
     if [[ -z "$account_alias" ]]; then

--- a/tests/README.md
+++ b/tests/README.md
@@ -42,6 +42,8 @@ Minimal zsh test framework and test suites for this repo.
 - `test-zeppelin.zsh`
 - `test-compat.zsh`
 - `test-electron-fix.zsh`
+- `test-op-help.zsh`
+- `test-zsh-help-filter.zsh`
 
 ## Run tests
 

--- a/tests/test-op-help.zsh
+++ b/tests/test-op-help.zsh
@@ -1,0 +1,75 @@
+#!/usr/bin/env zsh
+
+ROOT_DIR="$(cd "$(dirname "${0:A}")/.." && pwd)"
+source "$ROOT_DIR/tests/test-framework.zsh"
+
+# Stub `op` to fail loudly: any invocation marks the test impure.
+typeset -g _OP_STUB_CALLS=0
+op() {
+    (( _OP_STUB_CALLS++ ))
+    echo "op stub: must not be called during --help" >&2
+    return 99
+}
+
+# Source the module under test AFTER stubbing `op`.
+source "$ROOT_DIR/modules/secrets/1password-cli.zsh"
+
+typeset -ga _OP_PUBLIC_FUNCS=(
+    op_accounts_edit
+    op_accounts_sanitize
+    op_accounts_set_alias
+    op_accounts_seed
+    op_verify_accounts
+    op_set_default
+    op_list_accounts_vaults
+    op_list_items
+    op_find_item_across_accounts
+    op_signin_account
+    op_signin_all
+    op_sessions_source
+    op_set_default_alias
+)
+
+# One generated test per public function: --help returns 0, prints Usage,
+# does not invoke the op binary.
+_make_help_test() {
+    local fn="$1"
+    eval "
+test_${fn}_help_long() {
+    _OP_STUB_CALLS=0
+    local out rc
+    out=\$($fn --help 2>&1)
+    rc=\$?
+    assert_equal '0' \"\$rc\" '${fn} --help should exit 0'
+    assert_contains \"\$out\" 'Usage:' '${fn} --help should print Usage:'
+    assert_equal '0' \"\$_OP_STUB_CALLS\" '${fn} --help must not invoke op'
+}
+
+test_${fn}_help_short() {
+    _OP_STUB_CALLS=0
+    local rc
+    $fn -h >/dev/null 2>&1
+    rc=\$?
+    assert_equal '0' \"\$rc\" '${fn} -h should exit 0'
+    assert_equal '0' \"\$_OP_STUB_CALLS\" '${fn} -h must not invoke op'
+}
+"
+    register_test "${fn}_help_long"  "test_${fn}_help_long"
+    register_test "${fn}_help_short" "test_${fn}_help_short"
+}
+
+for fn in "${_OP_PUBLIC_FUNCS[@]}"; do
+    _make_help_test "$fn"
+done
+
+# Sanity: --help is recognized even when the function would normally
+# error on bad args (op_accounts_set_alias requires <alias> <uuid>).
+test_help_overrides_required_args() {
+    _OP_STUB_CALLS=0
+    local out rc
+    out=$(op_accounts_set_alias --help 2>&1)
+    rc=$?
+    assert_equal '0' "$rc" '--help bypasses required-arg check'
+    assert_contains "$out" 'Usage: op_accounts_set_alias' 'prints function-specific synopsis'
+}
+register_test "help_overrides_required_args" test_help_overrides_required_args

--- a/tests/test-zsh-help-filter.zsh
+++ b/tests/test-zsh-help-filter.zsh
@@ -65,7 +65,7 @@ zsh_help() {
         if [[ "$line" == "  "[a-zA-Z_]* ]]; then
             first_token="${${line##  }%% *}"
             lc_token="${first_token:l}"
-            if [[ "$lc_token" == *"$lc_filter"* ]]; then
+            if [[ "$lc_token" == "$lc_filter"* ]]; then
                 [[ -n "$current_header" ]] && printf '%s\n' "$current_header"
                 printf '%s\n' "$line"
                 printed=1
@@ -114,11 +114,25 @@ test_function_name_filter() {
     assert_false "[[ '$out' == *'op_signin_account'* ]]" 'exact-prefix match excludes other op_signin_*'
 }
 
-test_function_name_filter_substring() {
+test_function_name_filter_prefix() {
+    # Prefix match: zsh_help op_signin finds both op_signin_all and
+    # op_signin_account. zsh_help signin (no prefix) does NOT — users
+    # type the prefix they remember.
     local out
-    out=$(zsh_help signin)
-    assert_contains "$out" 'op_signin_all'      'substring matches op_signin_all'
-    assert_contains "$out" 'op_signin_account'  'substring matches op_signin_account'
+    out=$(zsh_help op_signin)
+    assert_contains "$out" 'op_signin_all'      'prefix matches op_signin_all'
+    assert_contains "$out" 'op_signin_account'  'prefix matches op_signin_account'
+}
+
+test_zsh_help_op_lists_op_commands() {
+    # Primary UX path: the user types `zsh_help op` and expects to see
+    # the op_* surface. Regression guard for the substring → prefix
+    # refactor (CodeRabbit feedback on PR #169).
+    local out
+    out=$(zsh_help op)
+    assert_contains "$out" 'op_signin_all'  'zsh_help op surfaces op_signin_all'
+    assert_contains "$out" 'op_signin_account' 'zsh_help op surfaces op_signin_account'
+    assert_contains "$out" 'op_accounts_edit'  'zsh_help op surfaces op_accounts_edit'
 }
 
 test_no_match() {
@@ -139,6 +153,7 @@ register_test "no_arg_full_dump"          test_no_arg_full_dump
 register_test "section_filter_secrets"    test_section_filter_secrets
 register_test "section_filter_disk"       test_section_filter_disk
 register_test "function_name_filter"      test_function_name_filter
-register_test "function_name_filter_sub"  test_function_name_filter_substring
+register_test "function_name_filter_pre"  test_function_name_filter_prefix
+register_test "zsh_help_op_lists_op"      test_zsh_help_op_lists_op_commands
 register_test "no_match"                  test_no_match
 register_test "case_insensitive"          test_case_insensitive

--- a/tests/test-zsh-help-filter.zsh
+++ b/tests/test-zsh-help-filter.zsh
@@ -1,0 +1,144 @@
+#!/usr/bin/env zsh
+
+ROOT_DIR="$(cd "$(dirname "${0:A}")/.." && pwd)"
+source "$ROOT_DIR/tests/test-framework.zsh"
+
+# Re-implement just the help body + filter from zshrc — sourcing the
+# whole zshrc into a test would drag every module. The filter is the
+# logic we want to test; the body is a fixture.
+_zsh_help_body() {
+    cat <<'EOF'
+🚀 ZSH Quick Reference
+====================
+
+🐍 Python:
+  py_env_switch [env]    - Switch Python environment
+  python_status          - Show current environment
+
+🔐 Secrets:
+  secrets_status         - Show secrets loader status
+  op_accounts_edit       - Edit 1Password account aliases
+  op_signin_all          - Sign in to all account aliases
+  op_signin_account      - Sign in to one account alias
+
+💽 Disk:
+  disk_audit [N]         - Top space consumers
+  disk_clean_caches      - Sweep regenerable caches
+
+📚 Full docs: example
+EOF
+}
+
+# Copy of the filter from zshrc (kept in sync by hand; if the filter
+# logic gets a third call site, hoist to a shared lib).
+zsh_help() {
+    local filter="${1:-}"
+    if [[ -z "$filter" ]]; then
+        _zsh_help_body
+        return 0
+    fi
+    local -a lines
+    lines=("${(@f)$(_zsh_help_body)}")
+    local lc_filter="${filter:l}"
+    local current_header="" lc_header="" line first_token lc_token
+    local -a section_buf
+    local -i printed=0 in_match_section=0
+    for line in "${lines[@]}"; do
+        if [[ "$line" == *:* && "$line" != "  "* && "$line" != "==="* && -n "$line" && "${line[1]}" != [a-zA-Z🚀📚] ]]; then
+            if (( in_match_section )); then
+                printf '%s\n' "${section_buf[@]}"
+                printed=1
+                in_match_section=0
+            fi
+            current_header="$line"
+            lc_header="${current_header:l}"
+            section_buf=("$current_header")
+            if [[ "$lc_header" == *"$lc_filter"* ]]; then
+                in_match_section=1
+            fi
+            continue
+        fi
+        if (( in_match_section )); then
+            section_buf+=("$line")
+            continue
+        fi
+        if [[ "$line" == "  "[a-zA-Z_]* ]]; then
+            first_token="${${line##  }%% *}"
+            lc_token="${first_token:l}"
+            if [[ "$lc_token" == *"$lc_filter"* ]]; then
+                [[ -n "$current_header" ]] && printf '%s\n' "$current_header"
+                printf '%s\n' "$line"
+                printed=1
+            fi
+        fi
+    done
+    if (( in_match_section )); then
+        printf '%s\n' "${section_buf[@]}"
+        printed=1
+    fi
+    if (( ! printed )); then
+        echo "zsh_help: no matches for '$filter' (try: zsh_help with no arg)" >&2
+        return 0
+    fi
+}
+
+test_no_arg_full_dump() {
+    local out
+    out=$(zsh_help)
+    assert_contains "$out" 'ZSH Quick Reference' 'no-arg call prints full reference'
+    assert_contains "$out" 'op_signin_all' 'no-arg call includes op_signin_all'
+    assert_contains "$out" 'disk_audit'    'no-arg call includes disk_audit'
+}
+
+test_section_filter_secrets() {
+    local out
+    out=$(zsh_help secrets)
+    assert_contains "$out" '🔐 Secrets:'    'section filter prints Secrets header'
+    assert_contains "$out" 'op_signin_all'  'section filter includes section body'
+    assert_false "[[ '$out' == *'Python:'* ]]" 'section filter excludes other sections'
+    assert_false "[[ '$out' == *'disk_audit'* ]]" 'section filter excludes disk section'
+}
+
+test_section_filter_disk() {
+    local out
+    out=$(zsh_help disk)
+    assert_contains "$out" 'disk_audit'    'disk section appears'
+    assert_false "[[ '$out' == *'op_signin_all'* ]]" 'op_signin_all not in disk section'
+}
+
+test_function_name_filter() {
+    local out
+    out=$(zsh_help op_signin_all)
+    assert_contains "$out" 'op_signin_all' 'function filter prints the target'
+    assert_contains "$out" '🔐 Secrets:'   'function filter prints section header for context'
+    assert_false "[[ '$out' == *'op_signin_account'* ]]" 'exact-prefix match excludes other op_signin_*'
+}
+
+test_function_name_filter_substring() {
+    local out
+    out=$(zsh_help signin)
+    assert_contains "$out" 'op_signin_all'      'substring matches op_signin_all'
+    assert_contains "$out" 'op_signin_account'  'substring matches op_signin_account'
+}
+
+test_no_match() {
+    local out rc
+    out=$(zsh_help foo_does_not_exist 2>&1)
+    rc=$?
+    assert_equal '0' "$rc"                  'no-match still exits 0'
+    assert_contains "$out" 'no matches for'  'no-match prints hint'
+}
+
+test_case_insensitive() {
+    local out
+    out=$(zsh_help SECRETS)
+    assert_contains "$out" '🔐 Secrets:' 'filter is case-insensitive'
+}
+
+register_test "no_arg_full_dump"          test_no_arg_full_dump
+register_test "section_filter_secrets"    test_section_filter_secrets
+register_test "section_filter_disk"       test_section_filter_disk
+register_test "function_name_filter"      test_function_name_filter
+register_test "function_name_filter_sub"  test_function_name_filter_substring
+register_test "no_match"                  test_no_match
+register_test "case_insensitive"          test_case_insensitive

--- a/wiki/Functions-Index.md
+++ b/wiki/Functions-Index.md
@@ -320,6 +320,7 @@ their source order. Underscore-prefixed helpers are included.
 
 - `_op_account_alias`
 - `_op_account_alias_for_uuid`
+- `_op_print_help`
 - `op_accounts_edit`
 - `op_accounts_sanitize`
 - `_op_accounts_write_kv`

--- a/zshrc
+++ b/zshrc
@@ -707,7 +707,9 @@ zsh_help() {
         if [[ "$line" == "  "[a-zA-Z_]* ]]; then
             first_token="${${line##  }%% *}"
             lc_token="${first_token:l}"
-            if [[ "$lc_token" == *"$lc_filter"* ]]; then
+            # Prefix match (not substring): zsh_help op finds op_*, not anything
+            # containing "op" in the middle.
+            if [[ "$lc_token" == "$lc_filter"* ]]; then
                 [[ -n "$current_header" ]] && printf '%s\n' "$current_header"
                 printf '%s\n' "$line"
                 printed=1

--- a/zshrc
+++ b/zshrc
@@ -414,7 +414,7 @@ fi
 builtin rehash
 
 # Help
-zsh_help() {
+_zsh_help_body() {
     echo "🚀 ZSH Quick Reference"
     echo "===================="
     echo ""
@@ -661,6 +661,67 @@ zsh_help() {
     echo "  claude_session [name]  - Print Claude resume command"
     echo ""
     echo "📚 Full docs: $ZSH_CONFIG_DIR/README.md"
+}
+
+# zsh_help [filter]
+#   No arg: print the full reference.
+#   filter is a section name (e.g. 'secrets', 'op', 'disk') or a
+#   function name (e.g. 'op_signin_all'). Section match prints the
+#   whole section; function match prints the matching line(s) with
+#   the section header for context. No match prints a hint.
+zsh_help() {
+    local filter="${1:-}"
+    if [[ -z "$filter" ]]; then
+        _zsh_help_body
+        return 0
+    fi
+    local -a lines
+    lines=("${(@f)$(_zsh_help_body)}")
+    local lc_filter="${filter:l}"
+    local current_header="" lc_header="" line lc_line first_token lc_token
+    local -a section_buf
+    local -i printed=0 in_match_section=0
+    for line in "${lines[@]}"; do
+        # Section header lines start with a non-ASCII glyph (emoji) and contain ':'.
+        if [[ "$line" == *:* && "$line" != "  "* && "$line" != "==="* && -n "$line" && "${line[1]}" != [a-zA-Z🚀📚] ]]; then
+            # Flush previous matched section
+            if (( in_match_section )); then
+                printf '%s\n' "${section_buf[@]}"
+                printed=1
+                in_match_section=0
+            fi
+            current_header="$line"
+            lc_header="${current_header:l}"
+            section_buf=("$current_header")
+            # Match if the filter appears in the header (e.g. 'secrets' matches '🔐 Secrets:')
+            if [[ "$lc_header" == *"$lc_filter"* ]]; then
+                in_match_section=1
+            fi
+            continue
+        fi
+        if (( in_match_section )); then
+            section_buf+=("$line")
+            continue
+        fi
+        # Per-line match: indented function/command lines look like "  fn_name ..."
+        if [[ "$line" == "  "[a-zA-Z_]* ]]; then
+            first_token="${${line##  }%% *}"
+            lc_token="${first_token:l}"
+            if [[ "$lc_token" == *"$lc_filter"* ]]; then
+                [[ -n "$current_header" ]] && printf '%s\n' "$current_header"
+                printf '%s\n' "$line"
+                printed=1
+            fi
+        fi
+    done
+    if (( in_match_section )); then
+        printf '%s\n' "${section_buf[@]}"
+        printed=1
+    fi
+    if (( ! printed )); then
+        echo "zsh_help: no matches for '$filter' (try: zsh_help with no arg)" >&2
+        return 0
+    fi
 }
 alias zhelp='zsh_help'
 


### PR DESCRIPTION
Closes #168.

## Summary

Two help-discoverability bugs in the secrets / 1Password surface, fixed together:

1. **`zsh_help` now accepts a filter.** No-arg behavior is unchanged. With a filter, prints either the matching section (e.g. `zsh_help op`, `zsh_help disk`) or the matching function lines with section header for context (`zsh_help op_signin_all`). No-match prints a hint.
2. **`-h` / `--help` on the 13 public `op_*` functions.** Previously silently ignored, so `op_signin_all --help` actually started signing in (verified live: `device not configured: /dev/tty` while attempting ElectInfo and Siege_Analytics). Now: prints a per-function synopsis via the new `_op_print_help` printer and returns 0 without side effects.

## Public-surface change

```
zsh_help               → unchanged (full dump)
zsh_help op            → just the Secrets section
zsh_help disk          → just the Disk section
zsh_help op_signin     → both op_signin_* lines with section header
zsh_help foo_unknown   → "no matches" hint, rc=0

<any of the 13 op_*> --help   → synopsis + return 0, no side effects
<any of the 13 op_*> -h       → same
```

## Tests

- `tests/test-zsh-help-filter.zsh` — 7 tests (full-dump, section filter, function filter, substring, case-insensitive, no-match).
- `tests/test-op-help.zsh` — 27 tests: one `--help` + one `-h` per public function, plus a `--help bypasses required-arg check` regression. Stubs `op` to fail loudly so any tested function calling `op` fails the test (this is the side-effect-free claim, mechanically enforced).

Full suite: **297 tests, 3 pre-existing local-env failures only** (python/spark/hadoop SDKMAN-path stubs, same baseline as PR #166), all 35 new tests green.

## Test plan

- [ ] CI green on `test (macos-latest)` and `test (ubuntu-latest)`
- [ ] `zsh_help op_signin_all` prints just that one line
- [ ] `op_signin_all --help` prints synopsis and does NOT attempt sign-in
- [ ] `zsh_help` (no arg) prints the full reference unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public commands now recognize `-h/--help` and print command-specific usage without executing normal behavior.
  * Quick-reference help (`zsh_help`) now supports an optional filter to show matching sections or commands/functions.
* **Tests**
  * Added Zsh test coverage to ensure all public `op_*` help flags work and to validate `zsh_help` filtering, including case-insensitive matches and no-match behavior.
* **Documentation**
  * Updated the function reference index and test suite listing to reflect the new help helper and test suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->